### PR TITLE
feat(spec): add envFrom support in containers

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -20,8 +20,9 @@ import (
 	"fmt"
 	"os"
 
-	pkgcmd "github.com/kedgeproject/kedge/pkg/cmd"
 	"github.com/spf13/cobra"
+
+	pkgcmd "github.com/kedgeproject/kedge/pkg/cmd"
 )
 
 // Variables

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -21,6 +21,7 @@ import (
 	"os"
 
 	pkgcmd "github.com/kedgeproject/kedge/pkg/cmd"
+
 	"github.com/spf13/cobra"
 )
 

--- a/docs/file-reference.md
+++ b/docs/file-reference.md
@@ -17,11 +17,9 @@ containers:
       secretKeyRef:
         name: wordpress
         key: MYSQL_ROOT_PASSWORD
-  - name: MYSQL_DATABASE
-    valueFrom:
-      configMapKeyRef:
-        key: MYSQL_DATABASE
-        name: database
+  envFrom:
+  - configMapRef:
+      name: database
   volumeMounts:
   - name: database
     mountPath: /var/lib/mysql
@@ -111,10 +109,32 @@ containers:
 health: <probe>
 ```
 
-This is `probe` spec. Rather than defining `livenessProbe` and `readinessProbe`, define only
-`health`. And then it gets copied in both in the resultant spec.
-But if `health` and `livenessProbe` or `readinessProbe` are defined simultaneously then the
-tool will error out.
+This is `probe` spec. Rather than defining `livenessProbe` and `readinessProbe`,
+define only `health`. And then it gets copied in both in the resultant spec.
+But if `health` and `livenessProbe` or `readinessProbe` are defined
+simultaneously then the tool will error out.
+
+#### envFrom
+
+```yaml
+envFrom:
+- configMapRef:
+    name: <string>
+```
+
+This is similar to the envFrom field in container which is added since Kubernetes
+1.6. `envFrom` is a list of references. Right now the only reference that is
+supported is of `configMap`. The `configMap` that you refer here, all the data
+from that `configMap` will be populated as `env` inside the container.
+
+The restriction being that the `configMap` also has to be defined in the file.
+If the `configMap` is not defined in the file under the root level field called
+`configMaps`, the tool will throw an error, since it has no way of knowing
+from where to populate the environment variables from.
+
+To read more about this field from the Kubernetes upstream docs see this:
+https://kubernetes.io/docs/api-reference/v1.6/#envfromsource-v1-core
+
 
 ## persistentVolumes
 
@@ -393,11 +413,9 @@ containers:
       secretKeyRef:
         name: wordpress
         key: MYSQL_ROOT_PASSWORD
-  - name: MYSQL_DATABASE
-    valueFrom:
-      configMapKeyRef:
-        key: MYSQL_DATABASE
-        name: database
+  envFrom:
+  - configMapRef:
+      name: database
   volumeMounts:
   - name: database
     mountPath: /var/lib/mysql

--- a/examples/all/db.yaml
+++ b/examples/all/db.yaml
@@ -6,11 +6,9 @@ containers:
     value: rootpasswd
   - name: MYSQL_PASSWORD
     value: wordpress
-  - name: MYSQL_DATABASE
-    valueFrom:
-      configMapKeyRef:
-        key: MYSQL_DATABASE
-        name: database
+  envFrom:
+  - configMapRef:
+      name: database
   - name: MYSQL_USER
     value: wordpress
   volumeMounts:

--- a/examples/envFrom/README.md
+++ b/examples/envFrom/README.md
@@ -1,0 +1,67 @@
+# envFrom
+
+For exporting environment variable inside a container which is defined in
+`configMap` referencing it can be a painful thing, so `envFrom` helps you import
+all the content inside a particular `configMap` into container as env.
+
+At container level you will need to define a field called `envFrom` as shown from
+the snippet [web.yaml](web.yaml):
+
+```yaml
+  envFrom:
+  - configMapRef:
+      name: web
+```
+
+Here `envFrom` is a list of various references. In above example we are referring
+a `configMap` called `web`. This means that populate all the data defined in
+`configMap` called `web`.
+
+This also imposes a restriction that you will need to define a `configMap` with
+same name(`web` in our case here) in the same file in the root level field called
+`configMaps`. See snippet from [web.yaml](web.yaml) below:
+
+```yaml
+configMaps:
+- data:
+    WORDPRESS_DB_NAME: wordpress
+    WORDPRESS_DB_HOST: "database:3306"
+```
+
+If the referred `configMap` is not defined then the tool will throw an error.
+
+So when this is defined the resulting output will have those `envs` populated
+for you as shown below:
+
+```yaml
+$ kedge generate -f web.yaml
+---
+...
+      containers:
+      - env:
+        - name: WORDPRESS_DB_PASSWORD
+          value: wordpress
+        - name: WORDPRESS_DB_USER
+          value: wordpress
+        - name: WORDPRESS_DB_HOST
+          valueFrom:
+            configMapKeyRef:
+              key: WORDPRESS_DB_HOST
+              name: web
+        - name: WORDPRESS_DB_NAME
+          valueFrom:
+            configMapKeyRef:
+              key: WORDPRESS_DB_NAME
+              name: web
+        image: wordpress:4
+        name: web
+```
+
+In the above converted output you can see that the envs `WORDPRESS_DB_HOST` and
+`WORDPRESS_DB_NAME` are auto-populated from the `configMap`.
+
+You might ask why not use the `envFrom` field that is available in the
+`container` from Kubernetes 1.6? The answer is lot of users of `kedge` are
+still not on latest Kubernetes so this is a way to use this awesome feature
+without having the need to use newer cluster, but with downside that you will
+have to define configMap in the same file.

--- a/examples/envFrom/db.yaml
+++ b/examples/envFrom/db.yaml
@@ -1,0 +1,19 @@
+name: database
+containers:
+- image: mariadb:10
+  env:
+  - name: MYSQL_ROOT_PASSWORD
+    value: rootpasswd
+  - name: MYSQL_PASSWORD
+    value: wordpress
+  envFrom:
+  - configMapRef:
+      name: database
+services:
+- name: database
+  ports:
+  - port: 3306
+configMaps:
+- data:
+    MYSQL_DATABASE: wordpress
+    MYSQL_USER: wordpress

--- a/examples/envFrom/web.yaml
+++ b/examples/envFrom/web.yaml
@@ -10,25 +10,12 @@ containers:
   envFrom:
   - configMapRef:
       name: web
-  livenessProbe:
-    httpGet:
-      path: /
-      port: 80
-    initialDelaySeconds: 120
-    timeoutSeconds: 5
-  readinessProbe:
-    httpGet:
-      path: /
-      port: 80
-    initialDelaySeconds: 5
-    timeoutSeconds: 2
 services:
 - name: wordpress
-  type: LoadBalancer
+  type: NodePort
   ports:
   - port: 8080
     targetPort: 80
-    endpoint: minikube.local
 configMaps:
 - data:
     WORDPRESS_DB_NAME: wordpress

--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -45,10 +45,23 @@ type IngressSpecMod struct {
 	ext_v1beta1.IngressSpec `json:",inline"`
 }
 
+// EnvFromSource represents the source of a set of ConfigMaps
+type EnvFromSource struct {
+	ConfigMapRef *ConfigMapEnvSource `json:"configMapRef,omitempty"`
+}
+
+// ConfigMapEnvSource selects a ConfigMap to populate the environment
+// variables with.
+type ConfigMapEnvSource struct {
+	Name string `json:"name,omitempty"`
+}
+
 type Container struct {
 	// one common definitions for livenessProbe and readinessProbe
 	// this allows to have only one place to define both probes (if they are the same)
-	Health           *api_v1.Probe `json:"health,omitempty"`
+	Health  *api_v1.Probe   `json:"health,omitempty"`
+	EnvFrom []EnvFromSource `json:"envFrom,omitempty"`
+
 	api_v1.Container `json:",inline"`
 }
 

--- a/tests/cmd/undefined-configmap/db.yaml
+++ b/tests/cmd/undefined-configmap/db.yaml
@@ -1,0 +1,16 @@
+name: database
+containers:
+- image: mariadb:10
+  envFrom:
+  - configMapRef:
+      name: database
+  - configMapRef:
+      name: db
+services:
+- name: database
+  ports:
+  - port: 3306
+configMaps:
+- data:
+    MYSQL_DATABASE: wordpress
+    MYSQL_USER: wordpress


### PR DESCRIPTION
Now users can use envFrom similar to kubernetes to import all envs from a configMap. This is supported only for configMap and no support for secret yet. Also this imposes the condition that user should define configMap in the same file at root level under field `configMaps`.

Fixes #43