### PR TITLE
add license header to all the code files

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2017 The Kedge Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package cmd
 
 import (

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2017 The Kedge Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package cmd
 
 import (

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2017 The Kedge Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package cmd
 
 import (

--- a/main.go
+++ b/main.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2017 The Kedge Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package main
 
 import "github.com/kedgeproject/kedge/cmd"

--- a/pkg/cmd/deploy.go
+++ b/pkg/cmd/deploy.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2017 The Kedge Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package cmd
 
 import (

--- a/pkg/cmd/generate.go
+++ b/pkg/cmd/generate.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2017 The Kedge Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package cmd
 
 import (

--- a/pkg/encoding/encoding.go
+++ b/pkg/encoding/encoding.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2017 The Kedge Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package encoding
 
 import (

--- a/pkg/encoding/encoding_test.go
+++ b/pkg/encoding/encoding_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2017 The Kedge Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package encoding
 
 import (

--- a/pkg/encoding/fix.go
+++ b/pkg/encoding/fix.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2017 The Kedge Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package encoding
 
 import (

--- a/pkg/encoding/fixtures/multiple_ports_no_names.go
+++ b/pkg/encoding/fixtures/multiple_ports_no_names.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2017 The Kedge Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package fixtures
 
 var MultiplePortsNoNames []byte = []byte(

--- a/pkg/encoding/fixtures/multiple_ports_no_names_app.go
+++ b/pkg/encoding/fixtures/multiple_ports_no_names_app.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2017 The Kedge Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package fixtures
 
 import (

--- a/pkg/encoding/fixtures/multiple_ports_some_with_names_some_without.go
+++ b/pkg/encoding/fixtures/multiple_ports_some_with_names_some_without.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2017 The Kedge Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package fixtures
 
 var MultiplePortsWithAndWithoutNames []byte = []byte(

--- a/pkg/encoding/fixtures/multiple_ports_some_with_names_some_without_app.go
+++ b/pkg/encoding/fixtures/multiple_ports_some_with_names_some_without_app.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2017 The Kedge Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package fixtures
 
 import (

--- a/pkg/encoding/fixtures/multiple_ports_with_names.go
+++ b/pkg/encoding/fixtures/multiple_ports_with_names.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2017 The Kedge Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package fixtures
 
 var MultiplePortsWithNames []byte = []byte(

--- a/pkg/encoding/fixtures/multiple_ports_with_names_app.go
+++ b/pkg/encoding/fixtures/multiple_ports_with_names_app.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2017 The Kedge Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package fixtures
 
 import (

--- a/pkg/encoding/fixtures/single_container.go
+++ b/pkg/encoding/fixtures/single_container.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2017 The Kedge Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package fixtures
 
 var SingleContainer []byte = []byte(

--- a/pkg/encoding/fixtures/single_container_app.go
+++ b/pkg/encoding/fixtures/single_container_app.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2017 The Kedge Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package fixtures
 
 import (

--- a/pkg/encoding/fixtures/single_persistent_volume.go
+++ b/pkg/encoding/fixtures/single_persistent_volume.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2017 The Kedge Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package fixtures
 
 var SinglePersistentVolume []byte = []byte(

--- a/pkg/encoding/fixtures/single_persistent_volume_app.go
+++ b/pkg/encoding/fixtures/single_persistent_volume_app.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2017 The Kedge Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package fixtures
 
 import (

--- a/pkg/encoding/fixtures/single_port_without_name.go
+++ b/pkg/encoding/fixtures/single_port_without_name.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2017 The Kedge Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package fixtures
 
 var SinglePortWithoutName []byte = []byte(

--- a/pkg/encoding/fixtures/single_port_without_name_app.go
+++ b/pkg/encoding/fixtures/single_port_without_name_app.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2017 The Kedge Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package fixtures
 
 import (

--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2017 The Kedge Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package spec
 
 import (

--- a/pkg/transform/fixtures/single_container_object.go
+++ b/pkg/transform/fixtures/single_container_object.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2017 The Kedge Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package fixtures
 
 import api_v1 "k8s.io/client-go/pkg/api/v1"

--- a/pkg/transform/kubernetes/kubernetes.go
+++ b/pkg/transform/kubernetes/kubernetes.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2017 The Kedge Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package kubernetes
 
 import (

--- a/pkg/transform/kubernetes/kubernetes_test.go
+++ b/pkg/transform/kubernetes/kubernetes_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2017 The Kedge Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package kubernetes
 
 import (

--- a/scripts/check-gofmt.sh
+++ b/scripts/check-gofmt.sh
@@ -1,5 +1,20 @@
 #!/bin/bash
 
+# Copyright 2017 The Kedge Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 # This checks if all go source files in current directory are format using gofmt
 
 GO_FILES=$(find . -path ./vendor -prune -o -name '*.go' -print )

--- a/scripts/check-vendor.sh
+++ b/scripts/check-vendor.sh
@@ -1,5 +1,19 @@
 #!/bin/bash
 
+# Copyright 2017 The Kedge Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Check if there are nested vendor dirs inside kedge vendor.
 # All dependencies should be flattened and there shouldn't be vendor in inside vendor.
 


### PR DESCRIPTION
```
/*
Copyright 2017 The Kedge Authors All rights reserved.

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
*/
```

Added this license to all the files using following command:

```bash
find . -name '*.go' -exec sed -si '1{h;s,.*,cat ~/tmp/lic/lic,ep;g}' '{}' +
```
source: https://unix.stackexchange.com/a/125472

Fixes #46 