### PR TITLE
add util file to pkg/cmd, refactor deploy,generate

### DIFF
--- a/pkg/cmd/deploy.go
+++ b/pkg/cmd/deploy.go
@@ -19,7 +19,6 @@ package cmd
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os/exec"
 
 	"github.com/kedgeproject/kedge/pkg/encoding"
@@ -30,12 +29,13 @@ import (
 )
 
 func Deploy(files []string) error {
-	for _, file := range files {
 
-		data, err := ioutil.ReadFile(file)
-		if err != nil {
-			return errors.Wrap(err, "file reading failed")
-		}
+	appData, err := getApplicationsFromFiles(files)
+	if err != nil {
+		return errors.Wrap(err, "unable to get kedge definitions from input files")
+	}
+
+	for _, data := range appData {
 
 		app, err := encoding.Decode(data)
 		if err != nil {

--- a/pkg/cmd/generate.go
+++ b/pkg/cmd/generate.go
@@ -18,10 +18,7 @@ package cmd
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
-	"regexp"
-	"strings"
 
 	"github.com/kedgeproject/kedge/pkg/encoding"
 	"github.com/kedgeproject/kedge/pkg/transform/kubernetes"
@@ -33,39 +30,9 @@ import (
 
 func Generate(files []string) error {
 
-	var appData [][]byte
-	for _, file := range files {
-
-		data, err := ioutil.ReadFile(file)
-		if err != nil {
-			return errors.Wrap(err, "file reading failed")
-		}
-
-		// The regular expression takes care of when triple dashes are in the
-		// starting of the file or when they are as a separate line somewhere
-		// in the middle of the file or at the end. Ideally this should be taken
-		// care by the yaml library since this is valid YAML syntax anyway,
-		// but right now neither the go-yaml/yaml (issue #232) nor the one
-		// that we use supports the multiple document structure, so yeah!
-		apps := regexp.MustCompile("(^|\n)---\n").Split(string(data), -1)
-		for _, app := range apps {
-			// strings.TrimSpace will remove all the extra whitespaces and
-			// newline characters, and then proceed only when the length of the
-			// string is more than 0
-			// this avoids passing empty input further in the program in cases
-			// like -
-			// ---			# avoids empty input here
-			// ---
-			// name: abc
-			// containers:
-			// ...
-			// ---
-			//				# avoids empty input here
-			// ---			# avoids empty input here
-			if len(strings.TrimSpace(app)) > 0 {
-				appData = append(appData, []byte(app))
-			}
-		}
+	appData, err := getApplicationsFromFiles(files)
+	if err != nil {
+		return errors.Wrap(err, "unable to get kedge definitions from input files")
 	}
 
 	for _, data := range appData {

--- a/pkg/cmd/util.go
+++ b/pkg/cmd/util.go
@@ -1,0 +1,46 @@
+package cmd
+
+import (
+	"io/ioutil"
+	"regexp"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+func getApplicationsFromFiles(files []string) ([][]byte, error) {
+	var appData [][]byte
+	for _, file := range files {
+		data, err := ioutil.ReadFile(file)
+		if err != nil {
+			return nil, errors.Wrap(err, "file reading failed")
+		}
+
+		// The regular expression takes care of when triple dashes are in the
+		// starting of the file or when they are as a separate line somewhere
+		// in the middle of the file or at the end. Ideally this should be taken
+		// care by the yaml library since this is valid YAML syntax anyway,
+		// but right now neither the go-yaml/yaml (issue #232) nor the one
+		// that we use supports the multiple document structure, so yeah!
+		apps := regexp.MustCompile("(^|\n)---\n").Split(string(data), -1)
+		for _, app := range apps {
+			// strings.TrimSpace will remove all the extra whitespaces and
+			// newline characters, and then proceed only when the length of the
+			// string is more than 0
+			// this avoids passing empty input further in the program in cases
+			// like -
+			// ---			# avoids empty input here
+			// ---
+			// name: abc
+			// containers:
+			// ...
+			// ---
+			//				# avoids empty input here
+			// ---			# avoids empty input here
+			if len(strings.TrimSpace(app)) > 0 {
+				appData = append(appData, []byte(app))
+			}
+		}
+	}
+	return appData, nil
+}

--- a/pkg/encoding/fix.go
+++ b/pkg/encoding/fix.go
@@ -20,8 +20,8 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/pkg/errors"
 	"github.com/kedgeproject/kedge/pkg/spec"
+	"github.com/pkg/errors"
 )
 
 func fixApp(app *spec.App) error {

--- a/pkg/transform/kubernetes/kubernetes.go
+++ b/pkg/transform/kubernetes/kubernetes.go
@@ -23,8 +23,8 @@ import (
 	"strings"
 
 	"github.com/davecgh/go-spew/spew"
-	"github.com/pkg/errors"
 	"github.com/kedgeproject/kedge/pkg/spec"
+	"github.com/pkg/errors"
 	"k8s.io/client-go/pkg/api"
 	"k8s.io/client-go/pkg/api/resource"
 	"k8s.io/client-go/pkg/runtime"


### PR DESCRIPTION
This commit creates a util.go file which currently contains the
getApplicationsFromFiles() function that is being used by both
deploy.go and generate.go.

This was done because there was inconsistency in the way files
were being dealth with in both the deploy.go and generate.go
files.

Fixes #91