### PR TITLE
run unit test and other basic test in travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+dist: trusty
+
+language: go
+
+# make this also work for forks
+go_import_path: github.com/kedgeproject/kedge
+
+matrix:
+  include:
+    - go: 1.6
+    - go: 1.7
+    - go: 1.8
+  allow_failures:
+    - go: 1.6
+
+install:
+  - true
+
+script:
+  - make test

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ validate: gofmt vet lint
 vet:
 	go vet $(PKGS)
 
+# golint errors are only recommendations
 .PHONY: lint
 lint:
 	golint $(PKGS)
@@ -48,9 +49,13 @@ gofmt:
 check-vendor:
 	./scripts/check-vendor.sh
 
+.PHONY: test-unit
+test-unit:
+	go test $(PKGS)
+
 # Run all tests
 .PHONY: test
-test: test-dep check-vendor validate install
+test: test-dep check-vendor validate test-unit
 
 # Install all the required test-dependencies before executing tests (only valid when running `make test`)
 .PHONY: test-dep


### PR DESCRIPTION
I know that we will use fabric8 in the future, but until then we need to have some besics check for PRs to prevent some basic mistakes like #105.

This runs some basic test on vendor directory, checks if files are formatted according to gofmt, and runs unit tests.



Currently unit tests with go 1.6 are failing with:
```
pkg/transform/kubernetes/kubernetes_test.go:44: t.Run undefined (type *testing.T has no field or method Run)
```

^ this uses something that is only  in go1.7 and up

I've marked go1.6 as allow failures.
We should consider dropping  support for go1.6.