### PR TITLE
Refactor modified PodSpec to PodSpecMod

### DIFF
--- a/pkg/encoding/fixtures/multiple_ports_no_names_app.go
+++ b/pkg/encoding/fixtures/multiple_ports_no_names_app.go
@@ -23,10 +23,12 @@ import (
 
 var MultiplePortsNoNamesApp spec.App = spec.App{
 	Name: "test",
-	Containers: []spec.Container{
-		{
-			Container: api_v1.Container{
-				Image: "nginx",
+	PodSpecMod: spec.PodSpecMod{
+		Containers: []spec.Container{
+			{
+				Container: api_v1.Container{
+					Image: "nginx",
+				},
 			},
 		},
 	},

--- a/pkg/encoding/fixtures/multiple_ports_some_with_names_some_without_app.go
+++ b/pkg/encoding/fixtures/multiple_ports_some_with_names_some_without_app.go
@@ -23,10 +23,12 @@ import (
 
 var MultiplePortsWithAndWithoutNamesApp spec.App = spec.App{
 	Name: "test",
-	Containers: []spec.Container{
-		{
-			Container: api_v1.Container{
-				Image: "nginx",
+	PodSpecMod: spec.PodSpecMod{
+		Containers: []spec.Container{
+			{
+				Container: api_v1.Container{
+					Image: "nginx",
+				},
 			},
 		},
 	},

--- a/pkg/encoding/fixtures/multiple_ports_with_names_app.go
+++ b/pkg/encoding/fixtures/multiple_ports_with_names_app.go
@@ -23,10 +23,12 @@ import (
 
 var MultiplePortsWithNamesApp spec.App = spec.App{
 	Name: "test",
-	Containers: []spec.Container{
-		{
-			Container: api_v1.Container{
-				Image: "nginx",
+	PodSpecMod: spec.PodSpecMod{
+		Containers: []spec.Container{
+			{
+				Container: api_v1.Container{
+					Image: "nginx",
+				},
 			},
 		},
 	},

--- a/pkg/encoding/fixtures/single_container_app.go
+++ b/pkg/encoding/fixtures/single_container_app.go
@@ -23,10 +23,12 @@ import (
 
 var SingleContainerApp spec.App = spec.App{
 	Name: "test",
-	Containers: []spec.Container{
-		{
-			Container: api_v1.Container{
-				Image: "nginx",
+	PodSpecMod: spec.PodSpecMod{
+		Containers: []spec.Container{
+			{
+				Container: api_v1.Container{
+					Image: "nginx",
+				},
 			},
 		},
 	},

--- a/pkg/encoding/fixtures/single_persistent_volume_app.go
+++ b/pkg/encoding/fixtures/single_persistent_volume_app.go
@@ -23,10 +23,12 @@ import (
 
 var SinglePersistentVolumeApp spec.App = spec.App{
 	Name: "test",
-	Containers: []spec.Container{
-		{
-			Container: api_v1.Container{
-				Image: "nginx",
+	PodSpecMod: spec.PodSpecMod{
+		Containers: []spec.Container{
+			{
+				Container: api_v1.Container{
+					Image: "nginx",
+				},
 			},
 		},
 	},

--- a/pkg/encoding/fixtures/single_port_without_name_app.go
+++ b/pkg/encoding/fixtures/single_port_without_name_app.go
@@ -23,10 +23,12 @@ import (
 
 var SinglePortWithoutNameApp spec.App = spec.App{
 	Name: "test",
-	Containers: []spec.Container{
-		{
-			Container: api_v1.Container{
-				Image: "nginx",
+	PodSpecMod: spec.PodSpecMod{
+		Containers: []spec.Container{
+			{
+				Container: api_v1.Container{
+					Image: "nginx",
+				},
 			},
 		},
 	},

--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -70,18 +70,19 @@ type ConfigMapMod struct {
 	Data map[string]string `json:"data,omitempty"`
 }
 
+type PodSpecMod struct {
+	Containers     []Container `json:"containers,omitempty"`
+	api_v1.PodSpec `json:",inline"`
+}
+
 type App struct {
-	Name              string             `json:"name"`
-	Replicas          *int32             `json:"replicas,omitempty"`
-	Labels            map[string]string  `json:"labels,omitempty"`
-	PersistentVolumes []PersistentVolume `json:"persistentVolumes,omitempty"`
-	ConfigMaps        []ConfigMapMod     `json:"configMaps,omitempty"`
-	Services          []ServiceSpecMod   `json:"services,omitempty"`
-	Ingresses         []IngressSpecMod   `json:"ingresses,omitempty"`
-
-	// overwrite containers from PodSpec
-	Containers []Container `json:"containers,omitempty"`
-
-	api_v1.PodSpec             `json:",inline"`
+	Name                       string             `json:"name"`
+	Replicas                   *int32             `json:"replicas,omitempty"`
+	Labels                     map[string]string  `json:"labels,omitempty"`
+	PersistentVolumes          []PersistentVolume `json:"persistentVolumes,omitempty"`
+	ConfigMaps                 []ConfigMapMod     `json:"configMaps,omitempty"`
+	Services                   []ServiceSpecMod   `json:"services,omitempty"`
+	Ingresses                  []IngressSpecMod   `json:"ingresses,omitempty"`
+	PodSpecMod                 `json:",inline"`
 	ext_v1beta1.DeploymentSpec `json:",inline"`
 }


### PR DESCRIPTION
The Kubernetes specs which we modify or add shortcuts to, are
in the format of <spec>Mod struct, example ServicePortMod,
IngressSpecMod, etc. This was not done for PodSpec in the App
struct till now.

This commit refactors the modified PodSpec out of the App struct
into PodSpecMod struct, and refactors tests.

Fixes #112