### PR TITLE
Add mention bot

### DIFF
--- a/.mention-bot
+++ b/.mention-bot
@@ -1,0 +1,10 @@
+{
+  "maxReviewers": 3, // 3 is enough
+  "numFilesToCheck": 5,
+  "message": "@pullRequester, thanks! @reviewers, please review this.",
+  "findPotentialReviewers": true,
+  "fileBlacklist": ["*.md"], // ignore documentation
+  "assignToReviewer": false,
+  "createReviewRequest": true,
+  "createComment": true,
+}


### PR DESCRIPTION
Adds a custom configuration file for mention bot:
https://github.com/facebook/mention-bot which will be eventually
enabled in order to ping people on relevant PR's.