### PR TITLE
Remove replicas from main app struct

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -18,9 +18,11 @@ package cmd
 
 import (
 	"fmt"
-	pkgcmd "github.com/kedgeproject/kedge/pkg/cmd"
-	"github.com/spf13/cobra"
 	"os"
+
+	pkgcmd "github.com/kedgeproject/kedge/pkg/cmd"
+
+	"github.com/spf13/cobra"
 )
 
 // Variables

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -18,9 +18,11 @@ package cmd
 
 import (
 	"fmt"
-	pkgcmd "github.com/kedgeproject/kedge/pkg/cmd"
-	"github.com/spf13/cobra"
 	"os"
+
+	pkgcmd "github.com/kedgeproject/kedge/pkg/cmd"
+
+	"github.com/spf13/cobra"
 )
 
 // Variables

--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -77,7 +77,6 @@ type PodSpecMod struct {
 
 type App struct {
 	Name                       string            `json:"name"`
-	Replicas                   *int32            `json:"replicas,omitempty"`
 	Labels                     map[string]string `json:"labels,omitempty"`
 	VolumeClaims               []VolumeClaim     `json:"volumeClaims,omitempty"`
 	ConfigMaps                 []ConfigMapMod    `json:"configMaps,omitempty"`


### PR DESCRIPTION
Since we are already embedding DeploymentSpec in App struct we don't need Replicas anymore, this was added when we never had any field to specify replicas.

Fixes #100