### PR TITLE
kedge <subcommand> errors out without -f/--files

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -21,7 +21,6 @@ import (
 	"os"
 
 	pkgcmd "github.com/kedgeproject/kedge/pkg/cmd"
-
 	"github.com/spf13/cobra"
 )
 
@@ -35,6 +34,10 @@ var createCmd = &cobra.Command{
 	Use:   "create",
 	Short: "Create the resource on the Kubernetes cluster",
 	Run: func(cmd *cobra.Command, args []string) {
+		if err := ifFilesPassed(CreateFiles); err != nil {
+			fmt.Println(err)
+			os.Exit(-1)
+		}
 		if err := pkgcmd.ExecuteKubectl(CreateFiles, "create"); err != nil {
 			fmt.Println(err)
 			os.Exit(-1)
@@ -44,5 +47,6 @@ var createCmd = &cobra.Command{
 
 func init() {
 	createCmd.Flags().StringArrayVarP(&CreateFiles, "files", "f", []string{}, "Specify files")
+	createCmd.MarkFlagRequired("files")
 	RootCmd.AddCommand(createCmd)
 }

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -21,7 +21,6 @@ import (
 	"os"
 
 	pkgcmd "github.com/kedgeproject/kedge/pkg/cmd"
-
 	"github.com/spf13/cobra"
 )
 
@@ -35,6 +34,10 @@ var deleteCmd = &cobra.Command{
 	Use:   "delete",
 	Short: "Delete the resource from the Kubernetes cluster",
 	Run: func(cmd *cobra.Command, args []string) {
+		if err := ifFilesPassed(DeleteFiles); err != nil {
+			fmt.Println(err)
+			os.Exit(-1)
+		}
 		if err := pkgcmd.ExecuteKubectl(DeleteFiles, "delete"); err != nil {
 			fmt.Println(err)
 			os.Exit(-1)
@@ -44,5 +47,6 @@ var deleteCmd = &cobra.Command{
 
 func init() {
 	deleteCmd.Flags().StringArrayVarP(&DeleteFiles, "files", "f", []string{}, "Specify files")
+	deleteCmd.MarkFlagRequired("files")
 	RootCmd.AddCommand(deleteCmd)
 }

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -34,6 +34,10 @@ var generateCmd = &cobra.Command{
 	Use:   "generate",
 	Short: "Generate Kubernetes resources from App definition",
 	Run: func(cmd *cobra.Command, args []string) {
+		if err := ifFilesPassed(AppFiles); err != nil {
+			fmt.Println(err)
+			os.Exit(-1)
+		}
 		if err := pkgcmd.Generate(AppFiles); err != nil {
 			fmt.Println(err)
 			os.Exit(-1)
@@ -43,5 +47,6 @@ var generateCmd = &cobra.Command{
 
 func init() {
 	generateCmd.Flags().StringArrayVarP(&AppFiles, "files", "f", []string{}, "input files")
+	generateCmd.MarkFlagRequired("files")
 	RootCmd.AddCommand(generateCmd)
 }

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -1,0 +1,10 @@
+package cmd
+
+import "github.com/pkg/errors"
+
+func ifFilesPassed(files []string) error {
+	if len(files) == 0 {
+		return errors.New("No files were passed. Please pass file(s) using '-f' or '--files'")
+	}
+	return nil
+}


### PR DESCRIPTION
Before this commit, running `kedge` subcommands without passing
any files would do nothing.

$ kedge deploy
$

$ kedge generate
$

$ kedge undeploy
$

This commit adds a check that input files are passed using -f or
--files flags, and if not, throws an error.

$ kedge generate
Error: Unable to validate input files: No files were passed. Please pass file(s) using '-f' or '--files'

The flags have also been marked as required, however, that takes
no effect, and there is an open issue on the spf13/cobra package
tracking the same - https://github.com/spf13/cobra/issues/206