### PR TITLE
rename persistentVolumes to volumeClaims

### DIFF
--- a/docs/file-reference.md
+++ b/docs/file-reference.md
@@ -33,7 +33,7 @@ services:
   - port: 8080
     targetPort: 80
     endpoint: minikube.external/foo
-persistentVolumes:
+volumeClaims:
 - name: database
   size: 500Mi
 configMaps:
@@ -136,10 +136,10 @@ To read more about this field from the Kubernetes upstream docs see this:
 https://kubernetes.io/docs/api-reference/v1.6/#envfromsource-v1-core
 
 
-## persistentVolumes
+## volumeClaims
 
 ```yaml
-persistentVolumes:
+volumeClaims:
 - <volume>
 - <volume>
 ```
@@ -447,7 +447,7 @@ ingresses:
           serviceName: wordpress
           servicePort: 8080
         path: /
-persistentVolumes:
+volumeClaims:
 - name: database
   size: 500Mi
   accessModes:

--- a/examples/all/db.yaml
+++ b/examples/all/db.yaml
@@ -32,7 +32,7 @@ services:
 - name: database
   ports:
   - port: 3306
-persistentVolumes:
+volumeClaims:
 - name: database
   size: 500Mi
 configMaps:

--- a/examples/allnomagic/db.yaml
+++ b/examples/allnomagic/db.yaml
@@ -43,7 +43,7 @@ services:
 - name: database
   ports:
   - port: 3306
-persistentVolumes:
+volumeClaims:
 - name: database
   resources:
     requests:

--- a/examples/customVol/README.md
+++ b/examples/customVol/README.md
@@ -13,11 +13,11 @@ Check out the following snippet from [db.yaml](./db.yaml)
 
 Here you mention what is the name of the volume from the root level in `name` field and then in `mountPath` define the path where you wanna mount the volume inside the container.
 
-- Secondly define root level `persistentVolumes`
+- Secondly define root level `volumeClaims`
 
 Check out the following snippet from [db.yaml](./db.yaml)
 ```yaml
-persistentVolumes:
+volumeClaims:
 - name: database
   size: 500Mi
   accessModes:
@@ -31,4 +31,4 @@ Field `accessModes` is optional and defaults to `ReadWriteOnce`.
 ## Ref:
 
 - [Container level Volume Mounts](https://kubernetes.io/docs/api-reference/v1.6/#volumemount-v1-core)
-- [PersistentVolumes](https://kubernetes.io/docs/api-reference/v1.6/#volume-v1-core)
+- [volumeClaims](https://kubernetes.io/docs/api-reference/v1.6/#volume-v1-core)

--- a/examples/customVol/db.yaml
+++ b/examples/customVol/db.yaml
@@ -17,6 +17,6 @@ services:
 - name: database
   ports:
   - port: 3306
-persistentVolumes:
+volumeClaims:
 - name: database
   size: 500Mi

--- a/pkg/encoding/fix.go
+++ b/pkg/encoding/fix.go
@@ -31,8 +31,8 @@ func fixApp(app *spec.App) error {
 		return errors.Wrap(err, "Unable to fix services")
 	}
 
-	// fix app.PersistentVolumes
-	if err := fixPersistentVolumes(app); err != nil {
+	// fix app.VolumeClaims
+	if err := fixVolumeClaims(app); err != nil {
 		return errors.Wrap(err, "Unable to fix persistentVolume")
 	}
 
@@ -67,16 +67,16 @@ func fixServices(app *spec.App) error {
 	return nil
 }
 
-func fixPersistentVolumes(app *spec.App) error {
-	for i, pVolume := range app.PersistentVolumes {
+func fixVolumeClaims(app *spec.App) error {
+	for i, pVolume := range app.VolumeClaims {
 		if pVolume.Name == "" {
-			if len(app.PersistentVolumes) == 1 {
+			if len(app.VolumeClaims) == 1 {
 				pVolume.Name = app.Name
 			} else {
 				return errors.New("More than one persistent volume mentioned, please specify name for each one")
 			}
 		}
-		app.PersistentVolumes[i] = pVolume
+		app.VolumeClaims[i] = pVolume
 	}
 	return nil
 }

--- a/pkg/encoding/fixtures/single_persistent_volume.go
+++ b/pkg/encoding/fixtures/single_persistent_volume.go
@@ -23,6 +23,6 @@ containers:
 services:
   - ports:
     - port: 8080
-persistentVolumes:
+volumeClaims:
 - size: 500Mi
 `)

--- a/pkg/encoding/fixtures/single_persistent_volume_app.go
+++ b/pkg/encoding/fixtures/single_persistent_volume_app.go
@@ -44,7 +44,7 @@ var SinglePersistentVolumeApp spec.App = spec.App{
 			},
 		},
 	},
-	PersistentVolumes: []spec.PersistentVolume{
+	VolumeClaims: []spec.VolumeClaim{
 		{
 			Name: "test",
 			Size: "500Mi",

--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -21,7 +21,7 @@ import (
 	ext_v1beta1 "k8s.io/client-go/pkg/apis/extensions/v1beta1"
 )
 
-type PersistentVolume struct {
+type VolumeClaim struct {
 	api_v1.PersistentVolumeClaimSpec `json:",inline"`
 	Name                             string `json:"name"`
 	Size                             string `json:"size"`
@@ -76,13 +76,13 @@ type PodSpecMod struct {
 }
 
 type App struct {
-	Name                       string             `json:"name"`
-	Replicas                   *int32             `json:"replicas,omitempty"`
-	Labels                     map[string]string  `json:"labels,omitempty"`
-	PersistentVolumes          []PersistentVolume `json:"persistentVolumes,omitempty"`
-	ConfigMaps                 []ConfigMapMod     `json:"configMaps,omitempty"`
-	Services                   []ServiceSpecMod   `json:"services,omitempty"`
-	Ingresses                  []IngressSpecMod   `json:"ingresses,omitempty"`
+	Name                       string            `json:"name"`
+	Replicas                   *int32            `json:"replicas,omitempty"`
+	Labels                     map[string]string `json:"labels,omitempty"`
+	VolumeClaims               []VolumeClaim     `json:"volumeClaims,omitempty"`
+	ConfigMaps                 []ConfigMapMod    `json:"configMaps,omitempty"`
+	Services                   []ServiceSpecMod  `json:"services,omitempty"`
+	Ingresses                  []IngressSpecMod  `json:"ingresses,omitempty"`
 	PodSpecMod                 `json:",inline"`
 	ext_v1beta1.DeploymentSpec `json:",inline"`
 }

--- a/pkg/transform/kubernetes/kubernetes.go
+++ b/pkg/transform/kubernetes/kubernetes.go
@@ -176,7 +176,7 @@ func createDeployment(app *spec.App) (*ext_v1beta1.Deployment, error) {
 
 // search through all the persistent volumes defined in the root level
 func isPVCDefined(app *spec.App, name string) bool {
-	for _, v := range app.PersistentVolumes {
+	for _, v := range app.VolumeClaims {
 		if v.Name == name {
 			return true
 		}
@@ -185,7 +185,7 @@ func isPVCDefined(app *spec.App, name string) bool {
 }
 
 // create PVC reading the root level persistent volume field
-func createPVC(v spec.PersistentVolume, labels map[string]string) (*api_v1.PersistentVolumeClaim, error) {
+func createPVC(v spec.VolumeClaim, labels map[string]string) (*api_v1.PersistentVolumeClaim, error) {
 	// check for conditions where user has given both conflicting fields
 	// or not given either fields
 	if v.Size != "" && v.Resources.Requests != nil {
@@ -363,7 +363,7 @@ func CreateK8sObjects(app *spec.App) ([]runtime.Object, error) {
 
 	// create pvc for each root level persistent volume
 	var pvcs []runtime.Object
-	for _, v := range app.PersistentVolumes {
+	for _, v := range app.VolumeClaims {
 		pvc, err := createPVC(v, app.Labels)
 		if err != nil {
 			return nil, errors.Wrapf(err, "app %q", app.Name)


### PR DESCRIPTION
This commit renames the persistentVolumes field and its JSON tag
in spec.App to volumeClaims.

Every other code change is a result of this refactor.
Docs and examples are also changed to accommodate this change.

Fixes #51