### PR TITLE
Upload binaries to Bintray

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,13 @@
 dist: trusty
 
 language: go
-
-# make this also work for forks
+# make it work for forks
 go_import_path: github.com/kedgeproject/kedge
+
+env:
+  global:
+    - secure: KcUiLEKL9iFkFxY76Xh/56fZE8PN9pjG2f2+9vtDkfEpKUg/Jen0XeVA4YTdQkTIqR/HTKCrG5HpwNZtBTE5TxJNfo8l4lqmq64Sgj7PLNWGpg8vsjvNc+28+4/8QpmRvOTszk+7RtgDfNRxcrf+t+oM1ZqsBHcRq46t6ASksSBQfRIy09kBQPiGXhqQ81EvqwpufW4VvAgVZEMx4SAXmkqzRzSu1WQtN6VCotP2CRkOBwnwKfiLVVv9I0qjLssLT9ExRzC54v22c/eO+FPsclzxYsLtbHjqOKGAC2b2NdbKLIjaMaMVEUskBRcfC9W7ILQwAbnI5i9HeL9Vo7aMXNIgzZUIxQ4wN3nMdEFKh4vIzO43x2RIstf+E4kobNKItVf1tgWOFzazS7YeuMUA4bqkMnWilNx5stpM3S41K8Dh1nyMCCt9KnXE32x16Xwiahz1Ud6XmzHPVmzgAvAtxTPv7jD4ujoWaUIygQwfgKPZmdTa+Gu77q8vIS5Hy/HlTSS0Cl7MVIFRdapcq5xH0MmG18reA7fXWZqJHl6EcounVhuSGTTn0DHEBP9+2yeQSEIWtiJ51qi3bkzsOHAi65vFZO+TC4P45HWKrDWitnXYff37goiicLPCzohSLt/d8vCu4GkkDgxiaaqdm8nn+Rc2naxZDtWTpFURoceKpPU=
+    - secure: IQ3g8SlmBkJG0y5FAjVH5CrgNGrk0UjULcYCGBqyC1ti6thKQkiF9oc+hmnCUMHmYfkpeQJDyRxJ0rJMvozk0DmHnAjqN7QllqyarDBHWZHIAC01k1Iwioe1OUfYT1ovrmCY3jojRycX5UQic7+2Qj6DT1g6qQCzyE3LoCuj1TvEZNIwD1WGjIxuPQ97S+yVPOt2ax457n2C0H6OzRRxAv0oq8QGJ5Ls6vBgqWf+6nY4t2CoFv5aDErS7SdSgGWWEcMX+iKiDgUc+ac1ZWbzo9Q+NEJ6+GZ6QALluN8TOfLhDTvmj+OC4E+dGjU2e+upbkqvm+T750reGaFmEiimuDNy9U3k5aV97x7Dd84hg9N1A15Ls5j+6CxsobGGb06wnHviGSrWma2a52Lj/5gE6d22AaXtKJSplt0U4kEMzQWnSuEL/3tMXpLA76WFpyiKwiQnYrtBmmX6+i/aV9a5WEqNfftDi2SxMWOAdCcSIpu5FZaeYcFA68aCdOcq/rG9ksZI2KesVa2ZUMHAaqLt9IQxC9MHzG5oS7QmPWRwsA0a29f1d8+sbb4cR+NCqrsE1uQMT7+VkP7ad/K6VWAmqNkOW8X8eM4POSs1SpTw0pVDbV/plA65ZBcX1kuEKwZSUmRx4H6WNCmue0d9Dvh24uE7yekF91tB0uqdB2bdaeQ=
 
 matrix:
   include:
@@ -18,3 +22,20 @@ install:
 
 script:
   - make test
+
+before_deploy:
+  - make cross
+  - ./scripts/generate-bintray-json.sh
+
+deploy:
+  provider: bintray
+  repo: kedgeproject/kedge
+  file: ./.bintray.json
+  user: "${BINTRAY_USER}"
+  key: "${BINTRAY_KEY}"
+  skip_cleanup: true
+  on:
+    branch: "**"
+    go: 1.8
+
+

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ install:
 # kompile kedge for multiple platforms
 .PHONY: cross
 cross:
+	go get github.com/mitchellh/gox
 	gox -osarch="darwin/amd64 linux/amd64 linux/arm windows/amd64" -output="bin/kedge-{{.OS}}-{{.Arch}}" $(BUILD_FLAGS)
 
 .PHONY: clean

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Kedge - Concise Application Definition for Kubernetes
 
-[![Build Status Widget]][Build Status] [![GoDoc Widget]][GoDoc] [![Slack Widget]][Slack]
+[![Build Status Widget]][Build Status] [![GoDoc Widget]][GoDoc] [![Slack Widget]][Slack] 
+
 
 
 ## What is Kedge?
@@ -24,8 +25,12 @@ Check out our [roadmap](ROADMAP.md) as we push towards a __0.1.0__ release.
 ## Using Kedge
 
 ### Installation
+You can download latest master build for all major operating systems and architectures.
+- [Linux (amd64)][Bintray Latest Linux]
+- [macOS (darwin)][Bintray Latest macOS]
+- [Windows (amd64)][Bintray Latest Windows]
 
-The _best_ way to try Kedge is to download the most up-to-date binary from the master GitHub branch:
+Or you can build it yourself from the master GitHub branch:
 
 ```sh
 go get github.com/kedgeproject/kedge
@@ -91,3 +96,6 @@ Unless otherwise stated (ex. `/vendor` files), all code is licensed under the [A
 [GoDoc Widget]: https://godoc.org/github.com/kedgeproject/kedge?status.svg
 [Slack]: http://slack.kedgeproject.org
 [Slack Widget]: https://s3.eu-central-1.amazonaws.com/ngtuna/join-us-on-slack.png
+[Bintray Latest Linux]:https://dl.bintray.com/kedgeproject/kedge/latest/kedge-linux-amd64
+[Bintray Latest macOS]:https://dl.bintray.com/kedgeproject/kedge/latest/kedge-darwin-amd64
+[Bintray Latest Windows]:https://dl.bintray.com/kedgeproject/kedge/latest/kedge-windows-amd64.exe

--- a/scripts/generate-bintray-json.sh
+++ b/scripts/generate-bintray-json.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+
+DATE=`date --iso-8601=date`
+TIME=`date --iso-8601=seconds`
+
+cat > "./.bintray.json" <<EOF
+{
+    "package": {
+        "name": "kedge",
+        "repo": "kedge",
+        "subject": "kedgeproject",
+        "desc": "Concise Application Definition for Kubernetes",
+        "website_url": "https://github.com/kedgeproject/kedge",
+        "issue_tracker_url": "https://github.com/kedgeproject/kedge/issues",
+        "vcs_url": "https://github.com/kedgeproject/kedge.git",
+        "licenses": ["Apache-2.0"],
+        "public_download_numbers": false,
+        "public_stats": false
+    },
+
+    "version": {
+        "name": "latest",
+        "desc": "Kedge build from master branch",
+        "released": "${DATE}",
+        "vcs_tag": "${TRAVIS_COMMIT}",
+        "attributes": [{"name": "TRAVIS_JOB_NUMBER", "values" : ["${TRAVIS_JOB_NUMBER}"], "type": "string"},
+                       {"name": "TRAVIS_JOB_ID", "values" : ["${TRAVIS_JOB_ID}"], "type": "string"},
+                       {"name": "TRAVIS_COMMIT", "values" : ["${TRAVIS_COMMIT}"], "type": "string"},
+                       {"name": "TRAVIS_BRANCH", "values" : ["${TRAVIS_BRANCH}"], "type": "string"},
+                       {"name": "TRAVIS_PULL_REQUEST", "values" : ["${TRAVIS_PULL_REQUEST}"], "type": "string"},
+                       {"name": "date", "values" : ["${TIME}"], "type": "date"}],
+        "gpgSign": false
+    },
+
+    "files":
+        [
+            {"includePattern": "bin/(.*)",
+             "uploadPattern": "./latest/\$1", 
+             "matrixParams": {"override": 1 }
+            }
+        ],
+    "publish": true
+}
+EOF


### PR DESCRIPTION
Kedge binary is automatically uploaded to Bintray CDN.

Build and upload happens every time there is a change in master branch.

There is no version history right now. Only the latest version is available.

I'll add a smarter version with history and with posting comments to PRs with link to binary in another PR.




Link to download latest binary is https://dl.bintray.com/kedgeproject/kedge/latest/kedge