### PR TITLE
fix indentation of example shown in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ services:
 We can now create this example on the Kubernetes cluster:
 
 ```sh
-kedge create -f httpd.yaml
+$ kedge create -f httpd.yaml
 deployment "httpd" created
 service "httpd" created
 ```
@@ -58,7 +58,7 @@ service "httpd" created
 And access it:
 
 ```sh
-kubectl get po,deploy,svc
+$ kubectl get po,deploy,svc
 NAME                        READY     STATUS    RESTARTS   AGE
 po/httpd-3617778768-ddlrs   1/1       Running   0          1m
 
@@ -69,7 +69,7 @@ NAME             CLUSTER-IP   EXTERNAL-IP   PORT(S)          AGE
 svc/httpd        10.0.0.187   <nodes>       8080:31385/TCP   1m
 svc/kubernetes   10.0.0.1     <none>        443/TCP          18h
 
-minikube service httpd
+$ minikube service httpd
 Opening kubernetes service default/httpd in default browser...
 ```
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -15,15 +15,15 @@ containers:
 services:
 - name: httpd
   type: NodePort
-    ports:
-      - port: 8080
-          targetPort: 80
+  ports:
+  - port: 8080
+    targetPort: 80
 ```
 
 __2. Now run the create command to deploy to Kubernetes!__
 
 ```sh
-kedge create -f httpd.yaml
+$ kedge create -f httpd.yaml
 deployment "httpd" created
 service "httpd" created
 ```
@@ -35,14 +35,14 @@ Now that your service has been deployed, let's access it.
 If you're already using `minikube` for your development process:
 
 ```sh
-minikube service httpd
+$ minikube service httpd
 Opening kubernetes service default/httpd in default browser...
 ```
 
 Otherwise, let's look up what IP your service is using!
 
 ```sh
-kubectl describe svc httpd
+$ kubectl describe svc httpd
 Name:                   httpd
 Namespace:              default
 Labels:                 app=httpd

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -12,7 +12,7 @@ Deploy directly to Kubernetes without creating the artifacts. Internally, Kedge 
 ### Deploy to Kubernetes
 
 ```sh
-kedge create -f httpd.yaml
+$ kedge create -f httpd.yaml
 deployment "httpd" created
 service "httpd" created
 ```
@@ -26,7 +26,7 @@ In these examples, we use the [simplest of examples](/examples/simplest/httpd.ya
 ### Convert to Kubernetes artifacts
 
 ```sh
-kedge generate -f httpd.yaml
+$ kedge generate -f httpd.yaml
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
@@ -73,7 +73,7 @@ status:
 Generation commands can also be "piped" to Kubernetes
 
 ```sh
-kedge generate -f httpd.yaml | kubectl create -f -
+$ kedge generate -f httpd.yaml | kubectl create -f -
 deployment "httpd" created
 service "httpd" created
 ```


### PR DESCRIPTION
Also fix the commands that have missing `$` sign this helps in distinguishing the command vs it's output