### PR TITLE
Make mention bot less aggressive

### DIFF
--- a/.mention-bot
+++ b/.mention-bot
@@ -1,5 +1,6 @@
 {
-  "numFilesToCheck": 10,
+  "maxReviewers": 1,
+  "numFilesToCheck": 5,
   "message": "@pullRequester, thank you for the pull request! We'll ping some people to review your PR. @reviewers, please review this.",
   "fileBlacklist": ["*.md"],
   "actions": ["opened", "labeled"],


### PR DESCRIPTION
Changes mention bot to only ping one person, and check upwards to three
files, for the most relevant reviewer.