### PR TITLE
 allow passing whole directory as -f argument

### DIFF
--- a/pkg/cmd/generate.go
+++ b/pkg/cmd/generate.go
@@ -28,7 +28,12 @@ import (
 	"k8s.io/client-go/pkg/runtime"
 )
 
-func Generate(files []string) error {
+func Generate(paths []string) error {
+
+	files, err := GetAllYAMLFiles(paths)
+	if err != nil {
+		return errors.Wrap(err, "unable to get YAML files")
+	}
 
 	inputs, err := getApplicationsFromFiles(files)
 	if err != nil {

--- a/pkg/cmd/kubernetes.go
+++ b/pkg/cmd/kubernetes.go
@@ -28,7 +28,12 @@ import (
 	"github.com/pkg/errors"
 )
 
-func ExecuteKubectl(files []string, command string) error {
+func ExecuteKubectl(paths []string, command string) error {
+
+	files, err := GetAllYAMLFiles(paths)
+	if err != nil {
+		return errors.Wrap(err, "unable to get YAML files")
+	}
 
 	inputs, err := getApplicationsFromFiles(files)
 	if err != nil {

--- a/pkg/cmd/util.go
+++ b/pkg/cmd/util.go
@@ -1,7 +1,9 @@
 package cmd
 
 import (
+	"fmt"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -55,4 +57,35 @@ func getApplicationsFromFiles(files []string) ([]inputData, error) {
 		}
 	}
 	return appData, nil
+}
+
+// GetAllYAMLFiles if path in argument is directory get all *.yml and *.yaml files
+// in that directory. If path is file just add it to output list as it is.
+func GetAllYAMLFiles(paths []string) ([]string, error) {
+	var files []string
+	for _, path := range paths {
+		fileInfo, err := os.Stat(path)
+		if err != nil {
+			return nil, errors.Wrapf(err, "can't get file info about %s", path)
+		}
+		if fileInfo.IsDir() {
+			ymlFiles, err := filepath.Glob(filepath.Join(path, "*.yml"))
+			if err != nil {
+				return nil, errors.Wrapf(err, "can't list *.yml files in %s", path)
+			}
+			files = append(files, ymlFiles...)
+			yamlFiles, err := filepath.Glob(filepath.Join(path, "*.yaml"))
+			if err != nil {
+				return nil, errors.Wrapf(err, "can't list *.yaml files in %s", path)
+			}
+			files = append(files, yamlFiles...)
+		} else {
+			// path is regular file, do nothing and just add it to list of files
+			files = append(files, path)
+		}
+	}
+	if len(files) == 0 {
+		return nil, fmt.Errorf("no *.yml or *.yaml files were found")
+	}
+	return files, nil
 }

--- a/pkg/cmd/util_test.go
+++ b/pkg/cmd/util_test.go
@@ -1,0 +1,80 @@
+package cmd
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+var matchFiles = []string{
+	"test.yml",
+	"foo/bar.yml",
+	"foo/bar.yaml",
+}
+
+// createMatchFiles crates empty files in tmpDir as defined in matchFiles
+func createMatchFiles(tmpDir string) error {
+	for _, file := range matchFiles {
+		fileName := filepath.Join(tmpDir, file)
+		// check if parrent directory exists
+		if _, err := os.Stat(filepath.Dir(fileName)); os.IsNotExist(err) {
+			// create parrent directory
+			err = os.MkdirAll(filepath.Dir(fileName), os.ModePerm)
+			if err != nil {
+				return err
+			}
+		}
+		// create empty files
+		_, err := os.OpenFile(fileName, os.O_RDONLY|os.O_CREATE, 0666)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+var matchTests = []struct {
+	paths  []string
+	result []string
+}{
+	{[]string{"test.yml"}, []string{"test.yml"}},
+	{[]string{"foo"}, []string{"foo/bar.yml", "foo/bar.yaml"}},
+	{[]string{"test.yml", "foo"}, []string{"test.yml", "foo/bar.yml", "foo/bar.yaml"}},
+}
+
+func TestGetAllYMLFiles(t *testing.T) {
+
+	// create temporary dir where all test files will be created
+	tmpDir, err := ioutil.TempDir("", "matchTest")
+	if err != nil {
+		t.Fatal("creating temp dir:", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	createMatchFiles(tmpDir)
+
+	for _, test := range matchTests {
+		var paths []string
+		var result []string
+		// prefix all test path with tmpDir
+		for _, p := range test.paths {
+			paths = append(paths, filepath.Join(tmpDir, p))
+		}
+		// prefix all expected results with tmpDir
+		for _, p := range test.result {
+			result = append(result, filepath.Join(tmpDir, p))
+		}
+
+		out, err := GetAllYAMLFiles(paths)
+		if err != nil {
+			t.Error(err)
+		}
+
+		if !reflect.DeepEqual(out, result) {
+			t.Errorf("output doesn't match expected output\n output  : %#v \n expected: %#v \n", out, result)
+		}
+	}
+
+}


### PR DESCRIPTION
if dir is provided, use all *.yml files in that directory

fixes #155 


TODO: 
- [x]  finish unit tests
- [x] maybe call `GetAllYMLFiles` from `ExecuteKubectl`?