### PR TITLE
define root level secrets and envFrom support

### DIFF
--- a/docs/file-reference.md
+++ b/docs/file-reference.md
@@ -12,14 +12,13 @@ name: database
 containers:
 - image: mariadb:10
   env:
-  - name: MYSQL_ROOT_PASSWORD
-    valueFrom:
-      secretKeyRef:
-        name: wordpress
-        key: MYSQL_ROOT_PASSWORD
+  - name: APPVERSION
+    value: 0.3.0
   envFrom:
   - configMapRef:
       name: database
+  - secretRef:
+      name: wordpress
   volumeMounts:
   - name: database
     mountPath: /var/lib/mysql
@@ -39,6 +38,10 @@ volumeClaims:
 configMaps:
 - data:
     MYSQL_DATABASE: wordpress
+secrets:
+- name: wordpress
+  data:
+    MYSQL_ROOT_PASSWORD: YWRtaW4=
 ```
 
 # Root level constructs
@@ -120,17 +123,16 @@ simultaneously then the tool will error out.
 envFrom:
 - configMapRef:
     name: <string>
+- secretRef:
+    name: <string>
 ```
 
 This is similar to the envFrom field in container which is added since Kubernetes
-1.6. `envFrom` is a list of references. Right now the only reference that is
-supported is of `configMap`. The `configMap` that you refer here, all the data
-from that `configMap` will be populated as `env` inside the container.
+1.6. All the data from the ConfigMaps and Secrets referred here will be populated
+as `env` inside the container.
 
-The restriction being that the `configMap` also has to be defined in the file.
-If the `configMap` is not defined in the file under the root level field called
-`configMaps`, the tool will throw an error, since it has no way of knowing
-from where to populate the environment variables from.
+The restriction is that the ConfigMaps and Secrets also have to be defined in the
+file since there is no way to get the data to be populated.
 
 To read more about this field from the Kubernetes upstream docs see this:
 https://kubernetes.io/docs/api-reference/v1.6/#envfromsource-v1-core
@@ -401,6 +403,61 @@ More info about Probe: https://kubernetes.io/docs/api-reference/v1.6/#probe-v1-c
 
 The name of the Ingress.
 
+## secrets
+
+```yaml
+secrets:
+- <secret>
+- <secret>
+```
+
+| **Type**                         | **Required** |
+|----------------------------------|--------------|
+| array of [secret](#secret) | no           |
+
+###secret
+
+```yaml
+name: string
+<Kubernetes Secret Definition>
+```
+
+The Kubernetes Secret resource is being reused here.
+More info: https://kubernetes.io/docs/api-reference/v1.6/#secret-v1-core
+
+So, the Kubernetes Secret resource allows specifying the secret data as base64
+encoded as well as in plaintext.
+This would look in kedge as:
+
+```yaml
+secrets:
+- name: <name of the secret>
+  data:
+    <secret data key>: <base64 encoded value of the secret data>
+  stringData:
+    <secret data key>: <plaintext value of the secret data>
+```
+
+example:
+
+```yaml
+secrets:
+- name: wordpress
+  data:
+    MYSQL_ROOT_PASSWORD: YWRtaW4=
+    MYSQL_PASSWORD: cGFzc3dvcmQ=
+```
+
+#### Name
+
+`name: wordpress`
+
+| **Type** | **Required** |
+|----------|--------------|
+| string   | yes          |
+
+The name of the secret. This is a mandatory field.
+
 ## Complete example
 
 ```yaml
@@ -408,14 +465,13 @@ name: database
 containers:
 - image: mariadb:10
   env:
-  - name: MYSQL_ROOT_PASSWORD
-    valueFrom:
-      secretKeyRef:
-        name: wordpress
-        key: MYSQL_ROOT_PASSWORD
+  - name: VERSION
+    value: v0.3.0
   envFrom:
   - configMapRef:
       name: database
+  - secretRef:
+      name: wordpress
   volumeMounts:
   - name: database
     mountPath: /var/lib/mysql
@@ -455,4 +511,8 @@ volumeClaims:
 configMaps:
 - data:
     MYSQL_DATABASE: wordpress
+secrets:
+- name: wordpress
+  data:
+    MYSQL_ROOT_PASSWORD: YWRtaW4=
 ```

--- a/docs/file-reference.md
+++ b/docs/file-reference.md
@@ -11,9 +11,6 @@ API are included):
 name: database
 containers:
 - image: mariadb:10
-  env:
-  - name: APPVERSION
-    value: 0.3.0
   envFrom:
   - configMapRef:
       name: database
@@ -464,9 +461,6 @@ The name of the secret.
 name: database
 containers:
 - image: mariadb:10
-  env:
-  - name: VERSION
-    value: v0.3.0
   envFrom:
   - configMapRef:
       name: database

--- a/docs/file-reference.md
+++ b/docs/file-reference.md
@@ -454,9 +454,9 @@ secrets:
 
 | **Type** | **Required** |
 |----------|--------------|
-| string   | yes          |
+| string   | no           |
 
-The name of the secret. This is a mandatory field.
+The name of the secret.
 
 ## Complete example
 

--- a/examples/secrets/README.md
+++ b/examples/secrets/README.md
@@ -1,14 +1,25 @@
 # Using secrets
 
-Using secret is similar to any other pod. As of now this does not provide a way to create a secret but only to consume it.
-
 Creating secret:
 
-```bash
-oc create secret generic wordpress --from-literal='MYSQL_ROOT_PASSWORD=rootpasswd,DB_PASSWD=wordpress'
+Create a secret by defining it at the root level -
+```yaml
+secrets:
+- name: wordpress
+  data:
+    MYSQL_ROOT_PASSWORD: YWRtaW4=
+    MYSQL_PASSWORD: cGFzc3dvcmQ=
 ```
 
 Now consuming it, see the snippet from [db.yaml](db.yaml):
+
+```yaml
+  envFrom:
+  - secretRef:
+      name: wordpress
+```
+
+Alternatively, it can also be consumed by referencing it manually in `env:`
 
 ```yaml
   env:

--- a/examples/secrets/README.md
+++ b/examples/secrets/README.md
@@ -10,6 +10,8 @@ secrets:
     MYSQL_ROOT_PASSWORD: YWRtaW4=
     MYSQL_PASSWORD: cGFzc3dvcmQ=
 ```
+Make sure everything put in the field `data:` is base64 encoded.
+For supplying plaintext secret data, use the field `stringData`.
 
 Now consuming it, see the snippet from [db.yaml](db.yaml):
 

--- a/examples/secrets/db.yaml
+++ b/examples/secrets/db.yaml
@@ -2,21 +2,19 @@ name: database
 containers:
 - image: mariadb:10
   env:
-  - name: MYSQL_ROOT_PASSWORD
-    valueFrom:
-      secretKeyRef:
-        name: wordpress
-        key: MYSQL_ROOT_PASSWORD
   - name: MYSQL_DATABASE
     value: wordpress
   - name: MYSQL_USER
     value: wordpress
-  - name: MYSQL_PASSWORD
-    valueFrom:
-      secretKeyRef:
-        name: wordpress
-        key: DB_PASSWD
+  envFrom:
+  - secretRef:
+      name: wordpress
 services:
 - name: database
   ports:
   - port: 3306
+secrets:
+- name: wordpress
+  data:
+    MYSQL_ROOT_PASSWORD: YWRtaW4=
+    MYSQL_PASSWORD: cGFzc3dvcmQ=

--- a/examples/secrets/web.yaml
+++ b/examples/secrets/web.yaml
@@ -9,7 +9,7 @@ containers:
     valueFrom:
       secretKeyRef:
         name: wordpress
-        key: DB_PASSWD
+        key: MYSQL_PASSWORD
   - name: WORDPRESS_DB_USER
     value: wordpress
   - name: WORDPRESS_DB_NAME

--- a/pkg/encoding/fix.go
+++ b/pkg/encoding/fix.go
@@ -45,6 +45,10 @@ func fixApp(app *spec.App) error {
 		return errors.Wrap(err, "unable to fix containers")
 	}
 
+	if err := fixSecrets(app); err != nil {
+		return errors.Wrap(err, "unable to fix secrets")
+	}
+
 	return nil
 }
 
@@ -94,6 +98,20 @@ func fixConfigMaps(app *spec.App) error {
 		for cdn, cd := range app.ConfigMaps {
 			if cd.Name == "" {
 				return fmt.Errorf("name not specified for app.configMaps[%d]", cdn)
+			}
+		}
+	}
+	return nil
+}
+
+func fixSecrets(app *spec.App) error {
+	// populate secret name only if one secret is specified
+	if len(app.Secrets) == 1 && app.Secrets[0].Name == "" {
+		app.Secrets[0].Name = app.Name
+	} else if len(app.Secrets) > 1 {
+		for i, sec := range app.Secrets {
+			if sec.Name == "" {
+				return fmt.Errorf("name not specified for app.secrets[%d]", i)
 			}
 		}
 	}

--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -63,6 +63,11 @@ type PodSpecMod struct {
 	api_v1.PodSpec `json:",inline"`
 }
 
+type SecretMod struct {
+	Name          string `json:"name,omitempty"`
+	api_v1.Secret `json:",inline"`
+}
+
 type App struct {
 	Name                       string            `json:"name"`
 	Labels                     map[string]string `json:"labels,omitempty"`
@@ -70,6 +75,7 @@ type App struct {
 	ConfigMaps                 []ConfigMapMod    `json:"configMaps,omitempty"`
 	Services                   []ServiceSpecMod  `json:"services,omitempty"`
 	Ingresses                  []IngressSpecMod  `json:"ingresses,omitempty"`
+	Secrets                    []SecretMod       `json:"secrets,omitempty"`
 	PodSpecMod                 `json:",inline"`
 	ext_v1beta1.DeploymentSpec `json:",inline"`
 }

--- a/pkg/transform/kubernetes/kubernetes.go
+++ b/pkg/transform/kubernetes/kubernetes.go
@@ -385,7 +385,7 @@ func createSecrets(app *spec.App) ([]runtime.Object, error) {
 
 	for _, s := range app.Secrets {
 		secret := &api_v1.Secret{
-			ObjectMeta: api_v1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:   s.Name,
 				Labels: app.Labels,
 			},

--- a/pkg/transform/kubernetes/kubernetes.go
+++ b/pkg/transform/kubernetes/kubernetes.go
@@ -281,62 +281,121 @@ func populateContainerHealth(app *spec.App) error {
 	return nil
 }
 
+func getConfigMapData(name string, configMaps []spec.ConfigMapMod) (map[string]string, error) {
+	for _, cm := range configMaps {
+		if cm.Name == name {
+			return cm.Data, nil
+		}
+	}
+	return nil, fmt.Errorf("configMap %v not defined", name)
+}
+
+func getSecretDataKeys(name string, secrets []spec.SecretMod) ([]string, error) {
+	var dataKeys []string
+	for _, secret := range secrets {
+		if secret.Name == name {
+			for dk := range secret.Data {
+				dataKeys = append(dataKeys, dk)
+			}
+			for sdk := range secret.StringData {
+				dataKeys = append(dataKeys, sdk)
+			}
+			return dataKeys, nil
+		}
+	}
+	return nil, fmt.Errorf("secret %v not defined", name)
+}
+
 func populateEnvFrom(app *spec.App) error {
 	// iterate on the containers so that we can extract envFrom
 	// that we have custom defined
 	for ci, c := range app.Containers {
-		for ei, e := range c.EnvFrom {
-			cmName := e.ConfigMapRef.Name
+		for _, e := range c.EnvFrom {
+			var envs []api_v1.EnvVar
 
-			// we also need to check if the configMap specified if it exists
-			var cmFound bool
-			// to populate the envs we also need to know the data
-			// from configmaps defined in the app
-			for _, cm := range app.ConfigMaps {
-				// we will only populate the configMap that is specified
-				// not every configMap out there
-				if cm.Name != cmName {
-					continue
+			// populating ConfigMaps
+			if e.ConfigMapRef != nil {
+				rootConfigMapData, err := getConfigMapData(e.ConfigMapRef.Name, app.ConfigMaps)
+				if err != nil {
+					return errors.Wrapf(err, "unable to get configMap: %v", e.ConfigMapRef.Name)
 				}
-				var envs []api_v1.EnvVar
+
 				// start populating
-				for k := range cm.Data {
+				for configMapDataKey := range rootConfigMapData {
 					// here we are directly referring to the containers
 					// from app.PodSpec.Containers because that is where data
 					// is parsed into so populating that is more valid thing to do
 					envs = append(envs, api_v1.EnvVar{
-						Name: k,
+						Name: configMapDataKey,
 						ValueFrom: &api_v1.EnvVarSource{
 							ConfigMapKeyRef: &api_v1.ConfigMapKeySelector{
 								LocalObjectReference: api_v1.LocalObjectReference{
-									Name: cmName,
+									Name: e.ConfigMapRef.Name,
 								},
-								Key: k,
+								Key: configMapDataKey,
 							},
 						},
 					})
 				}
-				// we collect all the envs from configMap before
-				// envs provided inside the container
-				envs = append(envs, app.PodSpec.Containers[ci].Env...)
-				app.PodSpec.Containers[ci].Env = envs
-
-				// this should be done when population is done
-				// TODO: when you add support for envFrom secret
-				// TODO: need to move this after secrets are also handled
-				app.PodSpec.Containers[ci].EnvFrom = nil
-
-				cmFound = true
-				// once the population is done we exit out of the loop
-				// we don't need to check other configMaps
-				break
 			}
-			if !cmFound {
-				return fmt.Errorf("undefined configMap in app.containers[%d].envFrom[%d].configMapRef.name", ci, ei)
+
+			// populating secrets
+			if e.SecretRef != nil {
+				rootSecretDataKeys, err := getSecretDataKeys(e.SecretRef.Name, app.Secrets)
+				if err != nil {
+					return errors.Wrap(err, "unable to get secret data")
+				}
+
+				for _, secretDataKey := range rootSecretDataKeys {
+					envs = append(envs, api_v1.EnvVar{
+						Name: secretDataKey,
+						ValueFrom: &api_v1.EnvVarSource{
+							SecretKeyRef: &api_v1.SecretKeySelector{
+								LocalObjectReference: api_v1.LocalObjectReference{
+									Name: e.SecretRef.Name,
+								},
+								Key: secretDataKey,
+							},
+						},
+					})
+				}
 			}
+
+			// we collect all the envs from configMap and secret before
+			// envs provided inside the container
+			envs = append(envs, app.PodSpec.Containers[ci].Env...)
+			app.PodSpec.Containers[ci].Env = envs
+		}
+
+		// Since we are not supporting envFrom in our generated Kubernetes
+		// artifacts right now, we need to set it as nil for every container.
+		// This makes sure that Kubernetes artifacts do not container an
+		// envFrom field.
+		// This is safe to set since all of the data from envFrom has been
+		// extracted till this point.
+		if app.PodSpec.Containers[ci].EnvFrom != nil {
+			app.PodSpec.Containers[ci].EnvFrom = nil
 		}
 	}
 	return nil
+}
+
+func createSecrets(app *spec.App) ([]runtime.Object, error) {
+	var secrets []runtime.Object
+
+	for _, s := range app.Secrets {
+		secret := &api_v1.Secret{
+			ObjectMeta: api_v1.ObjectMeta{
+				Name:   s.Name,
+				Labels: app.Labels,
+			},
+			Data:       s.Data,
+			StringData: s.StringData,
+			Type:       s.Type,
+		}
+		secrets = append(secrets, secret)
+	}
+	return secrets, nil
 }
 
 func CreateK8sObjects(app *spec.App) ([]runtime.Object, error) {
@@ -354,6 +413,11 @@ func CreateK8sObjects(app *spec.App) ([]runtime.Object, error) {
 	ings, err := createIngresses(app)
 	if err != nil {
 		return nil, errors.Wrap(err, "Unable to create Kubernetes Ingresses")
+	}
+
+	secs, err := createSecrets(app)
+	if err != nil {
+		return nil, errors.Wrap(err, "Unable to create Kubernetes Secrets")
 	}
 
 	// withdraw the health and populate actual pod spec
@@ -415,6 +479,9 @@ func CreateK8sObjects(app *spec.App) ([]runtime.Object, error) {
 
 	objects = append(objects, pvcs...)
 	log.Debugf("app: %s, pvc: %s\n", app.Name, spew.Sprint(pvcs))
+
+	objects = append(objects, secs...)
+	log.Debugf("app: %s, secret: %s\n", app.Name, spew.Sprint(secs))
 
 	return objects, nil
 }


### PR DESCRIPTION
~~meh, most of it is done, but need to take a final look, will update shortly~~

This commit allows defining root level secrets, as well as
referencing those from the `envFrom` directive, which currently
only supports configMaps.

Minor refactors have been made in kubernetes.go to handle envFrom
behavior for ConfigMaps and Secrets in a more consistent manner.

The examples, related READMEs, and the file reference doc have also
been modified to reflect the changes being brought upon.

fixes #128