### PR TITLE
feat(spec): add support for extraResources

### DIFF
--- a/docs/file-reference.md
+++ b/docs/file-reference.md
@@ -455,6 +455,31 @@ secrets:
 
 The name of the secret.
 
+## extraResources
+
+```yaml
+extraResources:
+- <string>
+- <string>
+```
+
+e.g.
+
+```yaml
+extraResources:
+- ./kubernetes/cron-job.yaml
+- secrets.yaml
+```
+
+This is list of files that are Kubernetes resources which can be passed to
+Kubernetes directly. On these list of files Kedge won't do any processing, but
+pass it to Kubernetes directly.
+
+The file path are relative to the kedge application file.
+
+This is one of the mechanisms to extend kedge beyond its capabilites to support
+anything in the Kubernetes land.
+
 ## Complete example
 
 ```yaml

--- a/examples/extraResources/README.md
+++ b/examples/extraResources/README.md
@@ -1,0 +1,29 @@
+# extraResources
+
+Kedge might not support all the things that Kubernetes has, but kedge would not
+come in your way to define anything that Kubernetes understands.
+
+For e.g. right now there is no way to define Kubernetes cron jobs in kedge,
+but you can still specify the Kubernetes cron job file. In this field called
+`extraResources`.
+
+See snippet from [app.yaml](app.yaml):
+
+```yaml
+extraResources:
+- cronjob.yaml
+```
+
+So in this way you can specify list of files under root level field called
+`extraResources`. These files have configuration that Kubernetes understands,
+kedge won't do any processing on these files and feed them directly to
+Kubernetes.
+
+Also the file paths under `extraResources` should be relative to the kedge file
+in which this config is specified.
+
+This does not change anything with respect to deploying applications.
+
+```console
+$ kedge create -f app.yaml
+```

--- a/examples/extraResources/app.yaml
+++ b/examples/extraResources/app.yaml
@@ -1,0 +1,16 @@
+name: web
+containers:
+- image: centos/httpd
+  volumeMounts:
+  - name: web
+    mountPath: /var/www/html/
+services:
+- name: web
+  type: NodePort
+  ports:
+  - port: 80
+volumeClaims:
+- name: web
+  size: 100Mi
+extraResources:
+- cronjob.yaml

--- a/examples/extraResources/cronjob.yaml
+++ b/examples/extraResources/cronjob.yaml
@@ -1,0 +1,26 @@
+apiVersion: batch/v2alpha1
+kind: CronJob
+metadata:
+  name: web
+spec:
+  schedule: "*/1 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: web
+            image: busybox
+            args:
+            - /bin/sh
+            - -c
+            - date > /var/www/html/index.html; echo 'Hello from the Kubernetes cluster' >> /var/www/html/index.html
+            volumeMounts:
+            - name: web
+              mountPath: /var/www/html/
+          restartPolicy: OnFailure
+          volumes:
+          - name: web
+            persistentVolumeClaim:
+              claimName: web
+

--- a/pkg/cmd/util.go
+++ b/pkg/cmd/util.go
@@ -12,7 +12,8 @@ import (
 )
 
 type inputData struct {
-	data []byte
+	fileName string
+	data     []byte
 }
 
 func getApplicationsFromFiles(files []string) ([]inputData, error) {
@@ -51,7 +52,8 @@ func getApplicationsFromFiles(files []string) ([]inputData, error) {
 			// ---			# avoids empty input here
 			if len(strings.TrimSpace(app)) > 0 {
 				appData = append(appData, inputData{
-					data: []byte(app),
+					fileName: file,
+					data:     []byte(app),
 				})
 			}
 		}

--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -75,6 +75,7 @@ type App struct {
 	Services                   []ServiceSpecMod  `json:"services,omitempty"`
 	Ingresses                  []IngressSpecMod  `json:"ingresses,omitempty"`
 	Secrets                    []SecretMod       `json:"secrets,omitempty"`
+	ExtraResources             []string          `json:"extraResources,omitempty"`
 	PodSpecMod                 `json:",inline"`
 	ext_v1beta1.DeploymentSpec `json:",inline"`
 }


### PR DESCRIPTION
With this root level field called `extraResources`, which is a list
of file names of Kubernetes artifacts that can be fed to Kubernetes
directly without kedge having to do any processing.

Anything that is not supported in kedge can be provided using this
field. Following is the example snippet of the app file that is
using `extraResources` field to deploy a `secret.yaml` and a
`cron-job.yaml` with the rest of kedge file. Here `secret.yaml` &
`cron-jobs.yaml` reside in the same directory.

e.g.

```
...
extraResources:
- secret.yaml
- cron-jobs.yaml
```

Fixes #157 