### PR TITLE
implement namespace specific cluster operations

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -34,7 +34,16 @@ var applyCmd = &cobra.Command{
 			fmt.Println(err)
 			os.Exit(-1)
 		}
-		if err := pkgcmd.ExecuteKubectl(InputFiles, "apply"); err != nil {
+
+		kubectlCommand := []string{"apply"}
+
+		// Only setting the namespace flag to kubectl when --namespace is passed
+		// explicitly by the user
+		if cmd.Flags().Lookup("namespace").Changed {
+			kubectlCommand = append(kubectlCommand, "--namespace", Namespace)
+		}
+
+		if err := pkgcmd.ExecuteKubectl(InputFiles, kubectlCommand...); err != nil {
 			fmt.Println(err)
 			os.Exit(-1)
 		}
@@ -43,5 +52,6 @@ var applyCmd = &cobra.Command{
 
 func init() {
 	applyCmd.Flags().StringArrayVarP(&InputFiles, "files", "f", []string{}, "Specify files")
+	applyCmd.Flags().StringVarP(&Namespace, "namespace", "n", "", "Kubernetes namespace to deploy your application to")
 	RootCmd.AddCommand(applyCmd)
 }

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -33,7 +33,16 @@ var createCmd = &cobra.Command{
 			fmt.Println(err)
 			os.Exit(-1)
 		}
-		if err := pkgcmd.ExecuteKubectl(InputFiles, "create"); err != nil {
+
+		kubectlCommand := []string{"create"}
+
+		// Only setting the namespace flag to kubectl when --namespace is passed
+		// explicitly by the user
+		if cmd.Flags().Lookup("namespace").Changed {
+			kubectlCommand = append(kubectlCommand, "--namespace", Namespace)
+		}
+
+		if err := pkgcmd.ExecuteKubectl(InputFiles, kubectlCommand...); err != nil {
 			fmt.Println(err)
 			os.Exit(-1)
 		}
@@ -43,5 +52,7 @@ var createCmd = &cobra.Command{
 func init() {
 	createCmd.Flags().StringArrayVarP(&InputFiles, "files", "f", []string{}, "Specify files")
 	createCmd.MarkFlagRequired("files")
+	createCmd.Flags().StringVarP(&Namespace, "namespace", "n", "", "Kubernetes namespace to deploy your application to")
+
 	RootCmd.AddCommand(createCmd)
 }

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -33,7 +33,16 @@ var deleteCmd = &cobra.Command{
 			fmt.Println(err)
 			os.Exit(-1)
 		}
-		if err := pkgcmd.ExecuteKubectl(InputFiles, "delete"); err != nil {
+
+		kubectlCommand := []string{"delete"}
+
+		// Only setting the namespace flag to kubectl when --namespace is passed
+		// explicitly by the user
+		if cmd.Flags().Lookup("namespace").Changed {
+			kubectlCommand = append(kubectlCommand, "--namespace", Namespace)
+		}
+
+		if err := pkgcmd.ExecuteKubectl(InputFiles, kubectlCommand...); err != nil {
 			fmt.Println(err)
 			os.Exit(-1)
 		}
@@ -43,5 +52,6 @@ var deleteCmd = &cobra.Command{
 func init() {
 	deleteCmd.Flags().StringArrayVarP(&InputFiles, "files", "f", []string{}, "Specify files")
 	deleteCmd.MarkFlagRequired("files")
+	deleteCmd.Flags().StringVarP(&Namespace, "namespace", "n", "", "Kubernetes namespace to delete your application from")
 	RootCmd.AddCommand(deleteCmd)
 }

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -2,6 +2,12 @@ package cmd
 
 import "github.com/pkg/errors"
 
+// Common global variables being used for kedge subcommands are declared here.
+// Before adding anything here, make sure that the subcommands using these
+// variables are mutually exclusive.
+// e.g. only one of `kedge generate` or `kedge create` can be run at a time,
+// so it makes sense to use the common InputFiles variable in both of those
+// commands.
 var (
 	InputFiles []string
 	Namespace  string

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -4,6 +4,7 @@ import "github.com/pkg/errors"
 
 var (
 	InputFiles []string
+	Namespace  string
 )
 
 func ifFilesPassed(files []string) error {

--- a/pkg/cmd/kubernetes.go
+++ b/pkg/cmd/kubernetes.go
@@ -28,7 +28,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-func ExecuteKubectl(paths []string, command string) error {
+func ExecuteKubectl(paths []string, command ...string) error {
 
 	files, err := GetAllYAMLFiles(paths)
 	if err != nil {
@@ -58,7 +58,11 @@ func ExecuteKubectl(paths []string, command string) error {
 				return errors.Wrap(err, "failed to marshal object")
 			}
 
-			cmd := exec.Command("kubectl", command, "-f", "-")
+			// We need to add "-f -" at the end of the command passed to us to
+			// pass the files.
+			// e.g. If the command is "apply --namespace staging", then the
+			// final command becomes "kubectl apply --namespace staging -f -"
+			cmd := exec.Command("kubectl", append(command, "-f", "-")...)
 
 			stdin, err := cmd.StdinPipe()
 			if err != nil {

--- a/pkg/cmd/kubernetes.go
+++ b/pkg/cmd/kubernetes.go
@@ -28,7 +28,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-func ExecuteKubectl(paths []string, command ...string) error {
+func ExecuteKubectl(paths []string, args ...string) error {
 
 	files, err := GetAllYAMLFiles(paths)
 	if err != nil {
@@ -62,7 +62,7 @@ func ExecuteKubectl(paths []string, command ...string) error {
 			// pass the files.
 			// e.g. If the command is "apply --namespace staging", then the
 			// final command becomes "kubectl apply --namespace staging -f -"
-			cmd := exec.Command("kubectl", append(command, "-f", "-")...)
+			cmd := exec.Command("kubectl", append(args, "-f", "-")...)
 
 			stdin, err := cmd.StdinPipe()
 			if err != nil {


### PR DESCRIPTION
This commit allows running "create", "delete" and "apply" kedge
subcommands with an optional "-n/--namespace" flag, which
specifies the Kubernetes namespace to perform the given operation
on.

The ExecuteKubectl() function in pkg/cmd/kubernetes.go is
refactored to accept multiple arguments to pass to "kubectl"
instead of just one, as before.

Fixes #93