### PR TITLE
add files passed check to apply.go

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -30,6 +30,10 @@ var applyCmd = &cobra.Command{
 	Use:   "apply",
 	Short: "Apply a configuration to a resource on the Kubernetes cluster. This resource will be created if it doesn't exist yet.",
 	Run: func(cmd *cobra.Command, args []string) {
+		if err := ifFilesPassed(InputFiles); err != nil {
+			fmt.Println(err)
+			os.Exit(-1)
+		}
 		if err := pkgcmd.ExecuteKubectl(InputFiles, "apply"); err != nil {
 			fmt.Println(err)
 			os.Exit(-1)


### PR DESCRIPTION
Before this commit, "kedge apply" did not check if files were
being passed to it or not. This commit adds that behavior and now,
"kedge apply" fails when no fails are passed to it using the
"-f/--files" flag.