### PR TITLE
refactor to reuse same InputFiles variable

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -23,17 +23,12 @@ import (
 	"os"
 )
 
-// Variables
-var (
-	ApplyFiles []string
-)
-
 // Represents the "apply" command
 var applyCmd = &cobra.Command{
 	Use:   "apply",
 	Short: "Apply a configuration to a resource on the Kubernetes cluster. This resource will be created if it doesn't exist yet.",
 	Run: func(cmd *cobra.Command, args []string) {
-		if err := pkgcmd.ExecuteKubectl(ApplyFiles, "apply"); err != nil {
+		if err := pkgcmd.ExecuteKubectl(InputFiles, "apply"); err != nil {
 			fmt.Println(err)
 			os.Exit(-1)
 		}
@@ -41,6 +36,6 @@ var applyCmd = &cobra.Command{
 }
 
 func init() {
-	applyCmd.Flags().StringArrayVarP(&ApplyFiles, "files", "f", []string{}, "Specify files")
+	applyCmd.Flags().StringArrayVarP(&InputFiles, "files", "f", []string{}, "Specify files")
 	RootCmd.AddCommand(applyCmd)
 }

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -24,21 +24,16 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// Variables
-var (
-	CreateFiles []string
-)
-
 // Represents the "create" command
 var createCmd = &cobra.Command{
 	Use:   "create",
 	Short: "Create the resource on the Kubernetes cluster",
 	Run: func(cmd *cobra.Command, args []string) {
-		if err := ifFilesPassed(CreateFiles); err != nil {
+		if err := ifFilesPassed(InputFiles); err != nil {
 			fmt.Println(err)
 			os.Exit(-1)
 		}
-		if err := pkgcmd.ExecuteKubectl(CreateFiles, "create"); err != nil {
+		if err := pkgcmd.ExecuteKubectl(InputFiles, "create"); err != nil {
 			fmt.Println(err)
 			os.Exit(-1)
 		}
@@ -46,7 +41,7 @@ var createCmd = &cobra.Command{
 }
 
 func init() {
-	createCmd.Flags().StringArrayVarP(&CreateFiles, "files", "f", []string{}, "Specify files")
+	createCmd.Flags().StringArrayVarP(&InputFiles, "files", "f", []string{}, "Specify files")
 	createCmd.MarkFlagRequired("files")
 	RootCmd.AddCommand(createCmd)
 }

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -24,21 +24,16 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// Variables
-var (
-	DeleteFiles []string
-)
-
 // Represents the "delete" command
 var deleteCmd = &cobra.Command{
 	Use:   "delete",
 	Short: "Delete the resource from the Kubernetes cluster",
 	Run: func(cmd *cobra.Command, args []string) {
-		if err := ifFilesPassed(DeleteFiles); err != nil {
+		if err := ifFilesPassed(InputFiles); err != nil {
 			fmt.Println(err)
 			os.Exit(-1)
 		}
-		if err := pkgcmd.ExecuteKubectl(DeleteFiles, "delete"); err != nil {
+		if err := pkgcmd.ExecuteKubectl(InputFiles, "delete"); err != nil {
 			fmt.Println(err)
 			os.Exit(-1)
 		}
@@ -46,7 +41,7 @@ var deleteCmd = &cobra.Command{
 }
 
 func init() {
-	deleteCmd.Flags().StringArrayVarP(&DeleteFiles, "files", "f", []string{}, "Specify files")
+	deleteCmd.Flags().StringArrayVarP(&InputFiles, "files", "f", []string{}, "Specify files")
 	deleteCmd.MarkFlagRequired("files")
 	RootCmd.AddCommand(deleteCmd)
 }

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -24,21 +24,16 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// Variables
-var (
-	AppFiles []string
-)
-
 // Represents the "generate" command
 var generateCmd = &cobra.Command{
 	Use:   "generate",
 	Short: "Generate Kubernetes resources from App definition",
 	Run: func(cmd *cobra.Command, args []string) {
-		if err := ifFilesPassed(AppFiles); err != nil {
+		if err := ifFilesPassed(InputFiles); err != nil {
 			fmt.Println(err)
 			os.Exit(-1)
 		}
-		if err := pkgcmd.Generate(AppFiles); err != nil {
+		if err := pkgcmd.Generate(InputFiles); err != nil {
 			fmt.Println(err)
 			os.Exit(-1)
 		}
@@ -46,7 +41,7 @@ var generateCmd = &cobra.Command{
 }
 
 func init() {
-	generateCmd.Flags().StringArrayVarP(&AppFiles, "files", "f", []string{}, "input files")
+	generateCmd.Flags().StringArrayVarP(&InputFiles, "files", "f", []string{}, "input files")
 	generateCmd.MarkFlagRequired("files")
 	RootCmd.AddCommand(generateCmd)
 }

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -2,6 +2,10 @@ package cmd
 
 import "github.com/pkg/errors"
 
+var (
+	InputFiles []string
+)
+
 func ifFilesPassed(files []string) error {
 	if len(files) == 0 {
 		return errors.New("No files were passed. Please pass file(s) using '-f' or '--files'")


### PR DESCRIPTION
cmd/apply.go, cmd/create.go, cmd/delete.go and cmd/generate.go
used to declate their own variable for taking input from files.

This commit adds a generic "InputFiles" variable in cmd/util.go
which is refered from all of these files since these operations
are mutually exclusive.