### PR TITLE
move containers fixing code to its function

### DIFF
--- a/pkg/encoding/encoding_test.go
+++ b/pkg/encoding/encoding_test.go
@@ -17,12 +17,12 @@ limitations under the License.
 package encoding
 
 import (
+	"encoding/json"
 	"reflect"
 	"testing"
 
 	"github.com/kedgeproject/kedge/pkg/spec"
 
-	"github.com/davecgh/go-spew/spew"
 	api_v1 "k8s.io/client-go/pkg/api/v1"
 )
 
@@ -44,7 +44,7 @@ services:
 			App: &spec.App{
 				Name: "test",
 				PodSpecMod: spec.PodSpecMod{
-					Containers: []spec.Container{{Container: api_v1.Container{Image: "nginx"}}},
+					Containers: []spec.Container{{Container: api_v1.Container{Name: "test", Image: "nginx"}}},
 				},
 				Services: []spec.ServiceSpecMod{
 					{Name: "test", Ports: []spec.ServicePortMod{{ServicePort: api_v1.ServicePort{Port: 8080}}}},
@@ -65,7 +65,7 @@ volumeClaims:
 			App: &spec.App{
 				Name: "test",
 				PodSpecMod: spec.PodSpecMod{
-					Containers: []spec.Container{{Container: api_v1.Container{Image: "nginx"}}},
+					Containers: []spec.Container{{Container: api_v1.Container{Name: "test", Image: "nginx"}}},
 				},
 				Services: []spec.ServiceSpecMod{
 					{Name: "test", Ports: []spec.ServicePortMod{{ServicePort: api_v1.ServicePort{Port: 8080}}}},
@@ -88,7 +88,7 @@ services:
 			App: &spec.App{
 				Name: "test",
 				PodSpecMod: spec.PodSpecMod{
-					Containers: []spec.Container{{Container: api_v1.Container{Image: "nginx"}}},
+					Containers: []spec.Container{{Container: api_v1.Container{Name: "test", Image: "nginx"}}},
 				},
 				Services: []spec.ServiceSpecMod{
 					{
@@ -119,7 +119,7 @@ services:
 			App: &spec.App{
 				Name: "test",
 				PodSpecMod: spec.PodSpecMod{
-					Containers: []spec.Container{{Container: api_v1.Container{Image: "nginx"}}},
+					Containers: []spec.Container{{Container: api_v1.Container{Name: "test", Image: "nginx"}}},
 				},
 				Services: []spec.ServiceSpecMod{
 					{
@@ -151,7 +151,7 @@ services:
 			App: &spec.App{
 				Name: "test",
 				PodSpecMod: spec.PodSpecMod{
-					Containers: []spec.Container{{Container: api_v1.Container{Image: "nginx"}}},
+					Containers: []spec.Container{{Container: api_v1.Container{Name: "test", Image: "nginx"}}},
 				},
 				Services: []spec.ServiceSpecMod{
 					{
@@ -177,7 +177,7 @@ services:
 			App: &spec.App{
 				Name: "test",
 				PodSpecMod: spec.PodSpecMod{
-					Containers: []spec.Container{{Container: api_v1.Container{Image: "nginx"}}},
+					Containers: []spec.Container{{Container: api_v1.Container{Name: "test", Image: "nginx"}}},
 				},
 				Services: []spec.ServiceSpecMod{
 					{Name: "test", Ports: []spec.ServicePortMod{{ServicePort: api_v1.ServicePort{Port: 8080}}}},
@@ -193,8 +193,13 @@ services:
 			}
 
 			if !reflect.DeepEqual(test.App, app) {
-				t.Fatalf("Expected:\n%v\nGot:\n%v", spew.Sprint(test.App), spew.Sprint(app))
+				t.Fatalf("==> Expected:\n%v\n==> Got:\n%v", prettyPrintObjects(test.App), prettyPrintObjects(app))
 			}
 		})
 	}
+}
+
+func prettyPrintObjects(v interface{}) string {
+	b, _ := json.MarshalIndent(v, "", "  ")
+	return string(b)
 }

--- a/pkg/encoding/fix.go
+++ b/pkg/encoding/fix.go
@@ -41,6 +41,10 @@ func fixApp(app *spec.App) error {
 		return errors.Wrap(err, "unable to fix configMaps")
 	}
 
+	if err := fixContainers(app); err != nil {
+		return errors.Wrap(err, "unable to fix containers")
+	}
+
 	return nil
 }
 
@@ -90,6 +94,22 @@ func fixConfigMaps(app *spec.App) error {
 		for cdn, cd := range app.ConfigMaps {
 			if cd.Name == "" {
 				return fmt.Errorf("name not specified for app.configMaps[%d]", cdn)
+			}
+		}
+	}
+	return nil
+}
+
+func fixContainers(app *spec.App) error {
+	// if only one container set name of it as app name
+	if len(app.Containers) == 1 && app.Containers[0].Name == "" {
+		app.Containers[0].Name = app.Name
+	} else if len(app.Containers) > 1 {
+		// check if all the containers have a name
+		// if not fail giving error
+		for cn, c := range app.Containers {
+			if c.Name == "" {
+				return fmt.Errorf("app %q: container name not defined for app.containers[%d]", app.Name, cn)
 			}
 		}
 	}

--- a/pkg/transform/kubernetes/kubernetes.go
+++ b/pkg/transform/kubernetes/kubernetes.go
@@ -375,19 +375,6 @@ func CreateK8sObjects(app *spec.App) ([]runtime.Object, error) {
 		return nil, errors.Wrapf(err, "app %q", app.Name)
 	}
 
-	// if only one container set name of it as app name
-	if len(app.PodSpec.Containers) == 1 && app.PodSpec.Containers[0].Name == "" {
-		app.PodSpec.Containers[0].Name = app.Name
-	} else if len(app.PodSpec.Containers) > 1 {
-		// check if all the containers have a name
-		// if not fail giving error
-		for cn, c := range app.PodSpec.Containers {
-			if c.Name == "" {
-				return nil, fmt.Errorf("app %q: container name not defined for app.containers[%d]", app.Name, cn)
-			}
-		}
-	}
-
 	var configMap []runtime.Object
 	for _, cd := range app.ConfigMaps {
 		cm := &api_v1.ConfigMap{


### PR DESCRIPTION
Right now the code that does fix for containers list
is part of createK8s function, moved it to fix.go
so this is where all fixers live.