### PR TITLE
Use upstream envFromSource than our created ones

### DIFF
--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -45,22 +45,10 @@ type IngressSpecMod struct {
 	ext_v1beta1.IngressSpec `json:",inline"`
 }
 
-// EnvFromSource represents the source of a set of ConfigMaps
-type EnvFromSource struct {
-	ConfigMapRef *ConfigMapEnvSource `json:"configMapRef,omitempty"`
-}
-
-// ConfigMapEnvSource selects a ConfigMap to populate the environment
-// variables with.
-type ConfigMapEnvSource struct {
-	Name string `json:"name,omitempty"`
-}
-
 type Container struct {
 	// one common definitions for livenessProbe and readinessProbe
 	// this allows to have only one place to define both probes (if they are the same)
-	Health  *api_v1.Probe   `json:"health,omitempty"`
-	EnvFrom []EnvFromSource `json:"envFrom,omitempty"`
+	Health *api_v1.Probe `json:"health,omitempty"`
 
 	api_v1.Container `json:",inline"`
 }

--- a/pkg/transform/kubernetes/kubernetes.go
+++ b/pkg/transform/kubernetes/kubernetes.go
@@ -321,6 +321,11 @@ func populateEnvFrom(app *spec.App) error {
 				envs = append(envs, app.PodSpec.Containers[ci].Env...)
 				app.PodSpec.Containers[ci].Env = envs
 
+				// this should be done when population is done
+				// TODO: when you add support for envFrom secret
+				// TODO: need to move this after secrets are also handled
+				app.PodSpec.Containers[ci].EnvFrom = nil
+
 				cmFound = true
 				// once the population is done we exit out of the loop
 				// we don't need to check other configMaps


### PR DESCRIPTION
When we were using the older client-go which had no `EnvFromSource` so we had to create one of our own. Now that we have moved to newer client-go we can use the structs from upstream.