### PR TITLE
Use kedge defined containers list for init containers

### DIFF
--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -59,6 +59,7 @@ type ConfigMapMod struct {
 
 type PodSpecMod struct {
 	Containers     []Container `json:"containers,conflicting,omitempty"`
+	InitContainers []Container `json:"initContainers,conflicting,omitempty"`
 	api_v1.PodSpec `json:",inline"`
 }
 

--- a/pkg/transform/kubernetes/kubernetes.go
+++ b/pkg/transform/kubernetes/kubernetes.go
@@ -315,6 +315,12 @@ func CreateK8sObjects(app *spec.App) ([]runtime.Object, []string, error) {
 	}
 	log.Debugf("object after population: %#v\n", app)
 
+	app.PodSpec.InitContainers, err = populateContainers(app.InitContainers, app.ConfigMaps, app.Secrets)
+	if err != nil {
+		return nil, nil, errors.Wrapf(err, "app %q", app.Name)
+	}
+	log.Debugf("object after population: %#v\n", app)
+
 	// create pvc for each root level persistent volume
 	var pvcs []runtime.Object
 	for _, v := range app.VolumeClaims {


### PR DESCRIPTION
We have added some features to containers struct in kedge.
Which is being used in the podSpec containers list. But right
now init-containers are using container type from upstream.
So changed it to use our type of containers list.

Fixes https://github.com/kedgeproject/kedge/issues/176