### PR TITLE
Abstract out the containers population of health and envFrom

### DIFF
--- a/pkg/transform/kubernetes/populators.go
+++ b/pkg/transform/kubernetes/populators.go
@@ -1,0 +1,164 @@
+package kubernetes
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/kedgeproject/kedge/pkg/spec"
+
+	"sort"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/pkg/errors"
+	api_v1 "k8s.io/client-go/pkg/api/v1"
+)
+
+func populateProbes(c spec.Container) (spec.Container, error) {
+	// check if health and liveness given together
+	if c.Health != nil && (c.ReadinessProbe != nil || c.LivenessProbe != nil) {
+		return c, fmt.Errorf("cannot define field 'health' and " +
+			"'livenessProbe' or 'readinessProbe' together")
+	}
+	if c.Health != nil {
+		c.LivenessProbe = c.Health
+		c.ReadinessProbe = c.Health
+		c.Health = nil
+	}
+	return c, nil
+}
+
+func searchConfigMap(cms []spec.ConfigMapMod, name string) (spec.ConfigMapMod, error) {
+	for _, cm := range cms {
+		if cm.Name == name {
+			return cm, nil
+		}
+	}
+	return spec.ConfigMapMod{}, fmt.Errorf("configMap %q not found", name)
+}
+
+func getSecretDataKeys(secrets []spec.SecretMod, name string) ([]string, error) {
+	var dataKeys []string
+	for _, secret := range secrets {
+		if secret.Name == name {
+			for dk := range secret.Data {
+				dataKeys = append(dataKeys, dk)
+			}
+			for sdk := range secret.StringData {
+				dataKeys = append(dataKeys, sdk)
+			}
+			return dataKeys, nil
+		}
+	}
+	return nil, fmt.Errorf("secret %q not found", name)
+}
+
+func getMapKeys(m map[string]string) []string {
+	var d []string
+	for k := range m {
+		d = append(d, k)
+	}
+	return d
+}
+
+func convertEnvFromToEnvs(envFrom []api_v1.EnvFromSource, cms []spec.ConfigMapMod, secrets []spec.SecretMod) ([]api_v1.EnvVar, error) {
+	var envs []api_v1.EnvVar
+
+	// we will iterate on all envFroms
+	for ei, e := range envFrom {
+		if e.ConfigMapRef != nil {
+
+			cmName := e.ConfigMapRef.Name
+
+			// see if the configMap name which is given actually exists
+			cm, err := searchConfigMap(cms, cmName)
+			if err != nil {
+				return nil, errors.Wrapf(err, "envFrom[%d].configMapRef.name", ei)
+			}
+			// once that configMap is found extract all data from it and create a env out of it
+			configMapKeys := getMapKeys(cm.Data)
+			sort.Strings(configMapKeys)
+			for _, key := range configMapKeys {
+				envs = append(envs, api_v1.EnvVar{
+					Name: key,
+					ValueFrom: &api_v1.EnvVarSource{
+						ConfigMapKeyRef: &api_v1.ConfigMapKeySelector{
+							LocalObjectReference: api_v1.LocalObjectReference{
+								Name: cmName,
+							},
+							Key: key,
+						},
+					},
+				})
+			}
+		}
+
+		if e.SecretRef != nil {
+			rootSecretDataKeys, err := getSecretDataKeys(secrets, e.SecretRef.Name)
+			if err != nil {
+				return nil, errors.Wrapf(err, "envFrom[%d].secretRef.name", ei)
+			}
+
+			sort.Strings(rootSecretDataKeys)
+			for _, secretDataKey := range rootSecretDataKeys {
+				envs = append(envs, api_v1.EnvVar{
+					Name: secretDataKey,
+					ValueFrom: &api_v1.EnvVarSource{
+						SecretKeyRef: &api_v1.SecretKeySelector{
+							LocalObjectReference: api_v1.LocalObjectReference{
+								Name: e.SecretRef.Name,
+							},
+							Key: secretDataKey,
+						},
+					},
+				})
+			}
+		}
+	}
+	return envs, nil
+}
+
+func populateEnvFrom(c spec.Container, cms []spec.ConfigMapMod, secrets []spec.SecretMod) (spec.Container, error) {
+	// now do the env from
+	envs, err := convertEnvFromToEnvs(c.EnvFrom, cms, secrets)
+	if err != nil {
+		return c, err
+	}
+	// Since we are not supporting envFrom in our generated Kubernetes
+	// artifacts right now, we need to set it as nil for every container.
+	// This makes sure that Kubernetes artifacts do not contain an
+	// envFrom field.
+	// This is safe to set since all of the data from envFrom has been
+	// extracted till this point.
+	c.EnvFrom = nil
+	// we collect all the envs from configMap before
+	// envs provided inside the container
+	envs = append(envs, c.Env...)
+	c.Env = envs
+	return c, nil
+}
+
+func populateContainers(containers []spec.Container, cms []spec.ConfigMapMod, secrets []spec.SecretMod) ([]api_v1.Container, error) {
+	var cnts []api_v1.Container
+
+	for cn, c := range containers {
+		// process health field
+		c, err := populateProbes(c)
+		if err != nil {
+			return cnts, errors.Wrapf(err, "error converting 'health' to 'probes', app.containers[%d]", cn)
+		}
+
+		// process envFrom field
+		c, err = populateEnvFrom(c, cms, secrets)
+		if err != nil {
+			return cnts, fmt.Errorf("error converting 'envFrom' to 'envs', app.containers[%d].%s", cn, err.Error())
+		}
+
+		// this is where we are only taking apart upstream container
+		// and not our own remix of containers
+		cnts = append(cnts, c.Container)
+	}
+
+	b, _ := json.MarshalIndent(cnts, "", "  ")
+	log.Debugf("containers after populating health: %s", string(b))
+	return cnts, nil
+}

--- a/pkg/transform/kubernetes/populators_test.go
+++ b/pkg/transform/kubernetes/populators_test.go
@@ -1,0 +1,594 @@
+package kubernetes
+
+import (
+	"encoding/json"
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/kedgeproject/kedge/pkg/spec"
+
+	api_v1 "k8s.io/client-go/pkg/api/v1"
+)
+
+func TestPopulateProbes(t *testing.T) {
+	t.Logf("Running failing tests")
+	failingTests := []struct {
+		name  string
+		input spec.Container
+	}{
+		{
+			name: "health and livenessProbe given together",
+			input: spec.Container{
+				Health: &api_v1.Probe{
+					Handler: api_v1.Handler{
+						Exec: &api_v1.ExecAction{Command: []string{"mysqladmin", "ping"}},
+					}, InitialDelaySeconds: 30, TimeoutSeconds: 5,
+				},
+				Container: api_v1.Container{
+					LivenessProbe: &api_v1.Probe{
+						Handler: api_v1.Handler{
+							Exec: &api_v1.ExecAction{Command: []string{"mysqladmin", "ping"}},
+						}, InitialDelaySeconds: 30, TimeoutSeconds: 5,
+					},
+				},
+			},
+		},
+		{
+			name: "health and readinessProbe given together",
+			input: spec.Container{
+				Health: &api_v1.Probe{
+					Handler: api_v1.Handler{
+						Exec: &api_v1.ExecAction{Command: []string{"mysqladmin", "ping"}},
+					}, InitialDelaySeconds: 30, TimeoutSeconds: 5,
+				},
+				Container: api_v1.Container{
+					ReadinessProbe: &api_v1.Probe{
+						Handler: api_v1.Handler{
+							Exec: &api_v1.ExecAction{Command: []string{"mysqladmin", "ping"}},
+						}, InitialDelaySeconds: 30, TimeoutSeconds: 5,
+					},
+				},
+			},
+		},
+		{
+			name: "health and livenessProbe and readinessProbe given together",
+			input: spec.Container{
+				Health: &api_v1.Probe{
+					Handler: api_v1.Handler{
+						Exec: &api_v1.ExecAction{Command: []string{"mysqladmin", "ping"}},
+					}, InitialDelaySeconds: 30, TimeoutSeconds: 5,
+				},
+				Container: api_v1.Container{
+					LivenessProbe: &api_v1.Probe{
+						Handler: api_v1.Handler{
+							Exec: &api_v1.ExecAction{Command: []string{"mysqladmin", "ping"}},
+						}, InitialDelaySeconds: 30, TimeoutSeconds: 5,
+					},
+					ReadinessProbe: &api_v1.Probe{
+						Handler: api_v1.Handler{
+							Exec: &api_v1.ExecAction{Command: []string{"mysqladmin", "ping"}},
+						}, InitialDelaySeconds: 30, TimeoutSeconds: 5,
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range failingTests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			if _, err := populateProbes(test.input); err == nil {
+				t.Fatalf("expected failure but passed for input: %s",
+					prettyPrintObjects(test.input))
+			} else {
+				t.Logf("failed with error: %v", err)
+			}
+		})
+	}
+
+	t.Logf("Running passing tests")
+	passingTests := []struct {
+		name   string
+		input  spec.Container
+		output spec.Container
+	}{
+		{
+			name: "valid health given",
+			input: spec.Container{
+				Health: &api_v1.Probe{
+					Handler: api_v1.Handler{
+						Exec: &api_v1.ExecAction{Command: []string{"mysqladmin", "ping"}},
+					}, InitialDelaySeconds: 30, TimeoutSeconds: 5,
+				},
+			},
+			output: spec.Container{
+				Container: api_v1.Container{
+					LivenessProbe: &api_v1.Probe{
+						Handler: api_v1.Handler{
+							Exec: &api_v1.ExecAction{Command: []string{"mysqladmin", "ping"}},
+						}, InitialDelaySeconds: 30, TimeoutSeconds: 5,
+					},
+					ReadinessProbe: &api_v1.Probe{
+						Handler: api_v1.Handler{
+							Exec: &api_v1.ExecAction{Command: []string{"mysqladmin", "ping"}},
+						}, InitialDelaySeconds: 30, TimeoutSeconds: 5,
+					},
+				},
+			},
+		},
+		{
+			name: "only livenessProbe given",
+			input: spec.Container{
+				Container: api_v1.Container{
+					LivenessProbe: &api_v1.Probe{
+						Handler: api_v1.Handler{
+							Exec: &api_v1.ExecAction{Command: []string{"mysqladmin", "ping"}},
+						}, InitialDelaySeconds: 30, TimeoutSeconds: 5,
+					},
+				},
+			},
+			output: spec.Container{
+				Container: api_v1.Container{
+					LivenessProbe: &api_v1.Probe{
+						Handler: api_v1.Handler{
+							Exec: &api_v1.ExecAction{Command: []string{"mysqladmin", "ping"}},
+						}, InitialDelaySeconds: 30, TimeoutSeconds: 5,
+					},
+				},
+			},
+		},
+		{
+			name: "only readinessProbe given",
+			input: spec.Container{
+				Container: api_v1.Container{
+					ReadinessProbe: &api_v1.Probe{
+						Handler: api_v1.Handler{
+							Exec: &api_v1.ExecAction{Command: []string{"mysqladmin", "ping"}},
+						}, InitialDelaySeconds: 30, TimeoutSeconds: 5,
+					},
+				},
+			},
+			output: spec.Container{
+				Container: api_v1.Container{
+					ReadinessProbe: &api_v1.Probe{
+						Handler: api_v1.Handler{
+							Exec: &api_v1.ExecAction{Command: []string{"mysqladmin", "ping"}},
+						}, InitialDelaySeconds: 30, TimeoutSeconds: 5,
+					},
+				},
+			},
+		},
+		{
+			name:   "nothing given",
+			input:  spec.Container{},
+			output: spec.Container{},
+		},
+	}
+
+	for _, test := range passingTests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := populateProbes(test.input)
+			if err != nil {
+				t.Fatalf("got error %v, for input: %s",
+					err, prettyPrintObjects(test.input))
+			}
+
+			if !reflect.DeepEqual(got, test.output) {
+				t.Fatalf("expected: %s, got: %s", prettyPrintObjects(test.output),
+					prettyPrintObjects(got))
+			}
+		})
+	}
+}
+
+func TestConvertMapToList(t *testing.T) {
+
+	tests := []struct {
+		input  map[string]string
+		output []string
+	}{
+		{
+			input:  map[string]string{"one": "", "two": "", "three": ""},
+			output: []string{"one", "three", "two"},
+		},
+		{
+			input:  map[string]string{"deployment": "", "application": "", "configMap": "", "containers": ""},
+			output: []string{"application", "configMap", "containers", "deployment"},
+		},
+	}
+
+	for _, test := range tests {
+		got := getMapKeys(test.input)
+		sort.Strings(got)
+		if !reflect.DeepEqual(test.output, got) {
+			t.Errorf("expected: %+v got: %+v", test.output, got)
+		}
+	}
+}
+
+var cms = []spec.ConfigMapMod{
+	{
+		Name: "test1", Data: map[string]string{"ten": "TEN"},
+	},
+	{
+		Name: "test2",
+		Data: map[string]string{"two": "TWO", "four": "FOUR", "eight": "EIGHT"},
+	},
+}
+var secrets = []spec.SecretMod{
+	{
+		Name: "test1",
+		Secret: api_v1.Secret{
+			Data:       map[string][]byte{"one": []byte("ONE"), "five": []byte("FIVE")},
+			StringData: map[string]string{"three": "THREE", "four": "FOUR"},
+		},
+	},
+	{
+		Name: "test2",
+		Secret: api_v1.Secret{
+			Data:       map[string][]byte{"one": []byte("ONE"), "two": []byte("TWO")},
+			StringData: map[string]string{"three": "THREE", "four": "FOUR"},
+		},
+	},
+	{
+		Name: "test3",
+	},
+}
+
+func TestSearchConfigMap(t *testing.T) {
+	t.Run("running passing test", func(t *testing.T) {
+		t.Parallel()
+		_, err := searchConfigMap(cms, "test2")
+		if err != nil {
+			t.Fatalf("%v", err)
+		}
+	})
+
+	t.Run("running failing test", func(t *testing.T) {
+		t.Parallel()
+		_, err := searchConfigMap(cms, "test5")
+		if err == nil {
+			t.Fatalf("should have failed but passed")
+		} else {
+			t.Logf("failed with error: %v", err)
+		}
+	})
+}
+
+func TestGetSecretDataKeys(t *testing.T) {
+	t.Run("running passing test", func(t *testing.T) {
+		t.Parallel()
+		// TODO: also check the returned keys the problem with it
+		// is that it is list which is generated from a map
+		// so order will change everytime so using reflect.DeepEqual won't
+		// be helpful
+		_, err := getSecretDataKeys(secrets, "test2")
+		if err != nil {
+			t.Fatalf("%v", err)
+		}
+	})
+
+	t.Run("running failing test", func(t *testing.T) {
+		t.Parallel()
+		_, err := getSecretDataKeys(secrets, "test5")
+		if err == nil {
+			t.Fatalf("should have failed but passed")
+		} else {
+			t.Logf("failed with error: %v", err)
+		}
+	})
+
+}
+
+func TestConvertEnvFromToEnvs(t *testing.T) {
+
+	// pass configmap and see all the envs
+	// pass secret and see all the envs
+	// pass configmap and secret and see all the envs
+	t.Logf("Running passing tests")
+	passingTests := []struct {
+		name   string
+		input  []api_v1.EnvFromSource
+		output []api_v1.EnvVar
+	}{
+		{
+			name: "all envs from configMap",
+			input: []api_v1.EnvFromSource{
+				{
+					ConfigMapRef: &api_v1.ConfigMapEnvSource{
+						LocalObjectReference: api_v1.LocalObjectReference{Name: "test2"},
+					},
+				},
+			},
+			output: []api_v1.EnvVar{
+				{
+					Name: "eight",
+					ValueFrom: &api_v1.EnvVarSource{
+						ConfigMapKeyRef: &api_v1.ConfigMapKeySelector{
+							LocalObjectReference: api_v1.LocalObjectReference{Name: "test2"},
+							Key:                  "eight",
+						},
+					},
+				},
+				{
+					Name: "four",
+					ValueFrom: &api_v1.EnvVarSource{
+						ConfigMapKeyRef: &api_v1.ConfigMapKeySelector{
+							LocalObjectReference: api_v1.LocalObjectReference{Name: "test2"},
+							Key:                  "four",
+						},
+					},
+				},
+				{
+					Name: "two",
+					ValueFrom: &api_v1.EnvVarSource{
+						ConfigMapKeyRef: &api_v1.ConfigMapKeySelector{
+							LocalObjectReference: api_v1.LocalObjectReference{Name: "test2"},
+							Key:                  "two",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "all envs from secret",
+			input: []api_v1.EnvFromSource{
+				{
+					SecretRef: &api_v1.SecretEnvSource{
+						LocalObjectReference: api_v1.LocalObjectReference{Name: "test2"},
+					},
+				},
+			},
+			output: []api_v1.EnvVar{
+				{
+					Name: "four",
+					ValueFrom: &api_v1.EnvVarSource{
+						SecretKeyRef: &api_v1.SecretKeySelector{
+							LocalObjectReference: api_v1.LocalObjectReference{Name: "test2"},
+							Key:                  "four",
+						},
+					},
+				},
+				{
+					Name: "one",
+					ValueFrom: &api_v1.EnvVarSource{
+						SecretKeyRef: &api_v1.SecretKeySelector{
+							LocalObjectReference: api_v1.LocalObjectReference{Name: "test2"},
+							Key:                  "one",
+						},
+					},
+				},
+				{
+					Name: "three",
+					ValueFrom: &api_v1.EnvVarSource{
+						SecretKeyRef: &api_v1.SecretKeySelector{
+							LocalObjectReference: api_v1.LocalObjectReference{Name: "test2"},
+							Key:                  "three",
+						},
+					},
+				},
+				{
+					Name: "two",
+					ValueFrom: &api_v1.EnvVarSource{
+						SecretKeyRef: &api_v1.SecretKeySelector{
+							LocalObjectReference: api_v1.LocalObjectReference{Name: "test2"},
+							Key:                  "two",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "envs from both secret and configmap",
+			input: []api_v1.EnvFromSource{
+				{
+					SecretRef: &api_v1.SecretEnvSource{
+						LocalObjectReference: api_v1.LocalObjectReference{Name: "test1"},
+					},
+					ConfigMapRef: &api_v1.ConfigMapEnvSource{
+						LocalObjectReference: api_v1.LocalObjectReference{Name: "test1"},
+					},
+				},
+			},
+			output: []api_v1.EnvVar{
+				{
+					Name: "ten",
+					ValueFrom: &api_v1.EnvVarSource{
+						ConfigMapKeyRef: &api_v1.ConfigMapKeySelector{
+							LocalObjectReference: api_v1.LocalObjectReference{Name: "test1"},
+							Key:                  "ten",
+						},
+					},
+				},
+				{
+					Name: "five",
+					ValueFrom: &api_v1.EnvVarSource{
+						SecretKeyRef: &api_v1.SecretKeySelector{
+							LocalObjectReference: api_v1.LocalObjectReference{Name: "test1"},
+							Key:                  "five",
+						},
+					},
+				},
+				{
+					Name: "four",
+					ValueFrom: &api_v1.EnvVarSource{
+						SecretKeyRef: &api_v1.SecretKeySelector{
+							LocalObjectReference: api_v1.LocalObjectReference{Name: "test1"},
+							Key:                  "four",
+						},
+					},
+				},
+				{
+					Name: "one",
+					ValueFrom: &api_v1.EnvVarSource{
+						SecretKeyRef: &api_v1.SecretKeySelector{
+							LocalObjectReference: api_v1.LocalObjectReference{Name: "test1"},
+							Key:                  "one",
+						},
+					},
+				},
+				{
+					Name: "three",
+					ValueFrom: &api_v1.EnvVarSource{
+						SecretKeyRef: &api_v1.SecretKeySelector{
+							LocalObjectReference: api_v1.LocalObjectReference{Name: "test1"},
+							Key:                  "three",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range passingTests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := convertEnvFromToEnvs(test.input, cms, secrets)
+			if err != nil {
+				t.Fatalf("errored out: %v", err)
+			}
+			if !reflect.DeepEqual(test.output, got) {
+				t.Fatalf("expected: %s, got: %s",
+					prettyPrintObjects(test.output), prettyPrintObjects(got))
+			}
+		})
+	}
+
+	t.Logf("Running failing tests")
+	failingTests := []struct {
+		name  string
+		input []api_v1.EnvFromSource
+	}{
+		{
+			name: "configMap that does not exists",
+			input: []api_v1.EnvFromSource{
+				{
+					ConfigMapRef: &api_v1.ConfigMapEnvSource{
+						LocalObjectReference: api_v1.LocalObjectReference{Name: "test9"},
+					},
+				},
+			},
+		},
+		{
+			name: "secret that does not exists",
+			input: []api_v1.EnvFromSource{
+				{
+					SecretRef: &api_v1.SecretEnvSource{
+						LocalObjectReference: api_v1.LocalObjectReference{Name: "test5"},
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range failingTests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := convertEnvFromToEnvs(test.input, cms, secrets)
+			if err == nil {
+				t.Fatalf("expected failure but passed for input: %s", prettyPrintObjects(test.input))
+			} else {
+				t.Logf("errored out with: %v", err)
+			}
+		})
+	}
+}
+
+func TestPopulateEnvFrom(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  spec.Container
+		output spec.Container
+	}{
+		{
+			name: "normal envFrom",
+			input: spec.Container{
+				Container: api_v1.Container{
+					EnvFrom: []api_v1.EnvFromSource{
+						{
+							ConfigMapRef: &api_v1.ConfigMapEnvSource{
+								LocalObjectReference: api_v1.LocalObjectReference{Name: "test1"},
+							},
+						},
+					},
+				},
+			},
+			output: spec.Container{
+				Container: api_v1.Container{
+					Env: []api_v1.EnvVar{
+						{
+							Name: "ten",
+							ValueFrom: &api_v1.EnvVarSource{
+								ConfigMapKeyRef: &api_v1.ConfigMapKeySelector{
+									LocalObjectReference: api_v1.LocalObjectReference{Name: "test1"},
+									Key:                  "ten",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "container that has envs already",
+			input: spec.Container{
+				Container: api_v1.Container{
+					EnvFrom: []api_v1.EnvFromSource{
+						{
+							ConfigMapRef: &api_v1.ConfigMapEnvSource{
+								LocalObjectReference: api_v1.LocalObjectReference{Name: "test1"},
+							},
+						},
+					},
+					Env: []api_v1.EnvVar{
+						{Name: "data", Value: "data"},
+						{Name: "ten", Value: "ten"},
+					},
+				},
+			},
+			output: spec.Container{
+				Container: api_v1.Container{
+					Env: []api_v1.EnvVar{
+						{
+							Name: "ten",
+							ValueFrom: &api_v1.EnvVarSource{
+								ConfigMapKeyRef: &api_v1.ConfigMapKeySelector{
+									LocalObjectReference: api_v1.LocalObjectReference{Name: "test1"},
+									Key:                  "ten",
+								},
+							},
+						},
+						{Name: "data", Value: "data"},
+						{Name: "ten", Value: "ten"},
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := populateEnvFrom(test.input, cms, secrets)
+			if err != nil {
+				t.Fatalf("errored: %v", err)
+			}
+			if !reflect.DeepEqual(test.output, got) {
+				t.Fatalf("expected: %s, got %s",
+					prettyPrintObjects(test.output), prettyPrintObjects(got))
+			}
+		})
+	}
+}
+
+func prettyPrintObjects(v interface{}) string {
+	b, _ := json.MarshalIndent(v, "", "  ")
+	return string(b)
+}


### PR DESCRIPTION
This way we remove the tight coupling of code with PodSpec.
This enables us to use the features with any other field that
has list of containers.

- [x] Write tests for individual functions