### PR TITLE
introduce an optional root level controller field

### DIFF
--- a/docs/file-reference.md
+++ b/docs/file-reference.md
@@ -9,6 +9,7 @@ API are included):
 
 ```yaml
 name: database
+controller: deployment
 containers:
 - image: mariadb:10
   envFrom:
@@ -56,6 +57,20 @@ More info: https://kubernetes.io/docs/api-reference/v1.6/#podspec-v1-core
 | string   | yes          |
 
 The name of the app or micro-service this particular file defines.
+
+## controller
+
+`controller: deployment`
+
+| **Type** | **Required** |
+|----------|--------------|
+| string   | no           |
+
+The Kubernetes controller of the app or micro-service this particular file
+defines.
+
+Supported controllers:
+- Deployment
 
 ## replicas
 

--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -80,3 +80,7 @@ type App struct {
 	PodSpecMod                 `json:",inline"`
 	ext_v1beta1.DeploymentSpec `json:",inline"`
 }
+
+type Controller struct {
+	Controller string `json:"controller,omitempty"`
+}


### PR DESCRIPTION
This commit introduces an optional root level controller field
which lets the user define the Kubernets controller to use for the
application.

If no controller is specified, the deployment controller is set.