### PR TITLE
check for duplicate volumeClaim definition

### DIFF
--- a/pkg/encoding/encoding.go
+++ b/pkg/encoding/encoding.go
@@ -41,9 +41,17 @@ func Decode(data []byte) (*spec.App, error) {
 			return nil, errors.Wrap(err, "could not unmarshal into internal struct")
 		}
 		log.Debugf("object unmarshalled: %#v\n", app)
+
+		// validate if the user provided input is valid kedge app
+		if err := validateApp(&app); err != nil {
+			return nil, errors.Wrapf(err, "error validating app %q", app.Name)
+		}
+
+		// this will add the default values where ever possible
 		if err := fixApp(&app); err != nil {
 			return nil, errors.Wrapf(err, "Unable to fix app %q", app.Name)
 		}
+
 		return &app, nil
 	default:
 		return nil, fmt.Errorf("invalid controller: %v", controller.Controller)

--- a/pkg/encoding/fix.go
+++ b/pkg/encoding/fix.go
@@ -21,6 +21,7 @@ import (
 	"strconv"
 
 	"github.com/kedgeproject/kedge/pkg/spec"
+
 	"github.com/pkg/errors"
 )
 

--- a/pkg/encoding/validate.go
+++ b/pkg/encoding/validate.go
@@ -1,0 +1,33 @@
+package encoding
+
+import (
+	"fmt"
+
+	"github.com/kedgeproject/kedge/pkg/spec"
+
+	"github.com/pkg/errors"
+)
+
+func validateVolumeClaims(vcs []spec.VolumeClaim) error {
+	// find the duplicate volume claim names, if found any then error out
+	vcmap := make(map[string]interface{})
+	for _, vc := range vcs {
+		if _, ok := vcmap[vc.Name]; !ok {
+			// value here does not matter
+			vcmap[vc.Name] = nil
+		} else {
+			return fmt.Errorf("duplicate entry of volume claim %q", vc.Name)
+		}
+	}
+	return nil
+}
+
+func validateApp(app *spec.App) error {
+
+	// validate volumeclaims
+	if err := validateVolumeClaims(app.VolumeClaims); err != nil {
+		return errors.Wrap(err, "error validating volume claims")
+	}
+
+	return nil
+}

--- a/pkg/encoding/validate_test.go
+++ b/pkg/encoding/validate_test.go
@@ -1,0 +1,20 @@
+package encoding
+
+import (
+	"testing"
+
+	"github.com/kedgeproject/kedge/pkg/spec"
+)
+
+func TestValidateVolumeClaims(t *testing.T) {
+
+	failingTest := []spec.VolumeClaim{{Name: "foo"}, {Name: "bar"}, {Name: "foo"}}
+
+	err := validateVolumeClaims(failingTest)
+	if err == nil {
+		t.Errorf("should have failed but passed for input: %+v", failingTest)
+	} else {
+		t.Logf("failed with error: %v", err)
+	}
+
+}

--- a/pkg/transform/kubernetes/populators.go
+++ b/pkg/transform/kubernetes/populators.go
@@ -3,10 +3,9 @@ package kubernetes
 import (
 	"encoding/json"
 	"fmt"
+	"sort"
 
 	"github.com/kedgeproject/kedge/pkg/spec"
-
-	"sort"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/pkg/errors"

--- a/tests/cmd/multi-pvc-same-name/app.yaml
+++ b/tests/cmd/multi-pvc-same-name/app.yaml
@@ -1,0 +1,9 @@
+name: foo
+containers:
+- image: foo
+volumeClaims:
+- name: foo
+  size: 5Mi
+- name: foo
+  size: 5Mi
+


### PR DESCRIPTION
If a volumeClaim with same name is defined now the checks are done,
to fail on such a case.

Fixes #55 