### PR TITLE
move files from package encoding to package spec

### DIFF
--- a/pkg/encoding/encoding.go
+++ b/pkg/encoding/encoding.go
@@ -43,12 +43,12 @@ func Decode(data []byte) (*spec.App, error) {
 		log.Debugf("object unmarshalled: %#v\n", app)
 
 		// validate if the user provided input is valid kedge app
-		if err := validateApp(&app); err != nil {
+		if err := spec.ValidateApp(&app); err != nil {
 			return nil, errors.Wrapf(err, "error validating app %q", app.Name)
 		}
 
 		// this will add the default values where ever possible
-		if err := fixApp(&app); err != nil {
+		if err := spec.FixApp(&app); err != nil {
 			return nil, errors.Wrapf(err, "Unable to fix app %q", app.Name)
 		}
 

--- a/pkg/spec/fix.go
+++ b/pkg/spec/fix.go
@@ -14,18 +14,16 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package encoding
+package spec
 
 import (
 	"fmt"
 	"strconv"
 
-	"github.com/kedgeproject/kedge/pkg/spec"
-
 	"github.com/pkg/errors"
 )
 
-func fixApp(app *spec.App) error {
+func FixApp(app *App) error {
 
 	// fix app.Services
 	if err := fixServices(app); err != nil {
@@ -53,7 +51,7 @@ func fixApp(app *spec.App) error {
 	return nil
 }
 
-func fixServices(app *spec.App) error {
+func fixServices(app *App) error {
 	for i, service := range app.Services {
 		// auto populate service name if only one service is specified
 		if service.Name == "" {
@@ -76,7 +74,7 @@ func fixServices(app *spec.App) error {
 	return nil
 }
 
-func fixVolumeClaims(app *spec.App) error {
+func fixVolumeClaims(app *App) error {
 	for i, pVolume := range app.VolumeClaims {
 		if pVolume.Name == "" {
 			if len(app.VolumeClaims) == 1 {
@@ -90,7 +88,7 @@ func fixVolumeClaims(app *spec.App) error {
 	return nil
 }
 
-func fixConfigMaps(app *spec.App) error {
+func fixConfigMaps(app *App) error {
 	// if only one configMap is defined and its name is not specified
 	if len(app.ConfigMaps) == 1 && app.ConfigMaps[0].Name == "" {
 		app.ConfigMaps[0].Name = app.Name
@@ -105,7 +103,7 @@ func fixConfigMaps(app *spec.App) error {
 	return nil
 }
 
-func fixSecrets(app *spec.App) error {
+func fixSecrets(app *App) error {
 	// populate secret name only if one secret is specified
 	if len(app.Secrets) == 1 && app.Secrets[0].Name == "" {
 		app.Secrets[0].Name = app.Name
@@ -119,7 +117,7 @@ func fixSecrets(app *spec.App) error {
 	return nil
 }
 
-func fixContainers(app *spec.App) error {
+func fixContainers(app *App) error {
 	// if only one container set name of it as app name
 	if len(app.Containers) == 1 && app.Containers[0].Name == "" {
 		app.Containers[0].Name = app.Name

--- a/pkg/spec/validate.go
+++ b/pkg/spec/validate.go
@@ -14,17 +14,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package encoding
+package spec
 
 import (
 	"fmt"
 
-	"github.com/kedgeproject/kedge/pkg/spec"
-
 	"github.com/pkg/errors"
 )
 
-func validateVolumeClaims(vcs []spec.VolumeClaim) error {
+func validateVolumeClaims(vcs []VolumeClaim) error {
 	// find the duplicate volume claim names, if found any then error out
 	vcmap := make(map[string]interface{})
 	for _, vc := range vcs {
@@ -38,7 +36,7 @@ func validateVolumeClaims(vcs []spec.VolumeClaim) error {
 	return nil
 }
 
-func validateApp(app *spec.App) error {
+func ValidateApp(app *App) error {
 
 	// validate volumeclaims
 	if err := validateVolumeClaims(app.VolumeClaims); err != nil {

--- a/pkg/spec/validate_test.go
+++ b/pkg/spec/validate_test.go
@@ -14,17 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package encoding
+package spec
 
-import (
-	"testing"
-
-	"github.com/kedgeproject/kedge/pkg/spec"
-)
+import "testing"
 
 func TestValidateVolumeClaims(t *testing.T) {
 
-	failingTest := []spec.VolumeClaim{{Name: "foo"}, {Name: "bar"}, {Name: "foo"}}
+	failingTest := []VolumeClaim{{Name: "foo"}, {Name: "bar"}, {Name: "foo"}}
 
 	err := validateVolumeClaims(failingTest)
 	if err == nil {


### PR DESCRIPTION
This commit is purely a refactor. Some files from pkg/encoding
have been moved to pkg/spec. This is the first part of a bigger
effort to consolidate all the controller specific functions and
methods under one package, i.e. package spec for now, so that we
can start defining new controllers on a codebase that's more
suited for extensibility.