### PR TITLE
move files from package kubernetes to package spec

### DIFF
--- a/pkg/cmd/generate.go
+++ b/pkg/cmd/generate.go
@@ -23,7 +23,7 @@ import (
 	"path/filepath"
 
 	"github.com/kedgeproject/kedge/pkg/encoding"
-	"github.com/kedgeproject/kedge/pkg/transform/kubernetes"
+	"github.com/kedgeproject/kedge/pkg/spec"
 
 	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
@@ -47,7 +47,7 @@ func Generate(paths []string) error {
 			return errors.Wrap(err, "unable to unmarshal data")
 		}
 
-		ros, extraResources, err := kubernetes.Transform(app)
+		ros, extraResources, err := spec.Transform(app)
 		if err != nil {
 			return errors.Wrap(err, "unable to transform data")
 		}

--- a/pkg/cmd/kubernetes.go
+++ b/pkg/cmd/kubernetes.go
@@ -22,7 +22,7 @@ import (
 	"os/exec"
 
 	"github.com/kedgeproject/kedge/pkg/encoding"
-	"github.com/kedgeproject/kedge/pkg/transform/kubernetes"
+	"github.com/kedgeproject/kedge/pkg/spec"
 
 	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
@@ -46,7 +46,7 @@ func ExecuteKubectl(paths []string, args ...string) error {
 			return errors.Wrap(err, "unable to unmarshal data")
 		}
 
-		ros, extraResources, err := kubernetes.Transform(app)
+		ros, extraResources, err := spec.Transform(app)
 		if err != nil {
 			return errors.Wrap(err, "unable to convert data")
 		}

--- a/pkg/spec/kubernetes.go
+++ b/pkg/spec/kubernetes.go
@@ -14,15 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package kubernetes
+package spec
 
 import (
 	"fmt"
 	"reflect"
 	"strconv"
 	"strings"
-
-	"github.com/kedgeproject/kedge/pkg/spec"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/davecgh/go-spew/spew"
@@ -40,12 +38,12 @@ import (
 	_ "k8s.io/client-go/pkg/apis/extensions/install"
 )
 
-func getLabels(app *spec.App) map[string]string {
+func getLabels(app *App) map[string]string {
 	labels := map[string]string{"app": app.Name}
 	return labels
 }
 
-func createIngresses(app *spec.App) ([]runtime.Object, error) {
+func createIngresses(app *App) ([]runtime.Object, error) {
 	var ings []runtime.Object
 
 	for _, i := range app.Ingresses {
@@ -61,7 +59,7 @@ func createIngresses(app *spec.App) ([]runtime.Object, error) {
 	return ings, nil
 }
 
-func createServices(app *spec.App) ([]runtime.Object, error) {
+func createServices(app *App) ([]runtime.Object, error) {
 	var svcs []runtime.Object
 	for _, s := range app.Services {
 		svc := &api_v1.Service{
@@ -134,7 +132,7 @@ func createServices(app *spec.App) ([]runtime.Object, error) {
 
 // Creates a Deployment Kubernetes resource. The returned Deployment resource
 // will be nil if it could not be generated due to insufficient input data.
-func createDeployment(app *spec.App) (*ext_v1beta1.Deployment, error) {
+func createDeployment(app *App) (*ext_v1beta1.Deployment, error) {
 
 	// We need to error out if both, app.PodSpec and app.DeploymentSpec are empty
 	if reflect.DeepEqual(app.PodSpec, api_v1.PodSpec{}) && reflect.DeepEqual(app.DeploymentSpec, ext_v1beta1.DeploymentSpec{}) {
@@ -176,7 +174,7 @@ func createDeployment(app *spec.App) (*ext_v1beta1.Deployment, error) {
 }
 
 // create PVC reading the root level persistent volume field
-func createPVC(v spec.VolumeClaim, labels map[string]string) (*api_v1.PersistentVolumeClaim, error) {
+func createPVC(v VolumeClaim, labels map[string]string) (*api_v1.PersistentVolumeClaim, error) {
 	// check for conditions where user has given both conflicting fields
 	// or not given either fields
 	if v.Size != "" && v.Resources.Requests != nil {
@@ -216,7 +214,7 @@ func createPVC(v spec.VolumeClaim, labels map[string]string) (*api_v1.Persistent
 	return pvc, nil
 }
 
-func createSecrets(app *spec.App) ([]runtime.Object, error) {
+func createSecrets(app *App) ([]runtime.Object, error) {
 	var secrets []runtime.Object
 
 	for _, s := range app.Secrets {
@@ -234,11 +232,11 @@ func createSecrets(app *spec.App) ([]runtime.Object, error) {
 	return secrets, nil
 }
 
-// CreateK8sObjects, if given object spec.App, this function reads
+// CreateK8sObjects, if given object App, this function reads
 // them and returns kubernetes objects as list of runtime.Object
 // If the app is using field 'extraResources' then it will
 // also return file names mentioned there as list of string
-func CreateK8sObjects(app *spec.App) ([]runtime.Object, []string, error) {
+func CreateK8sObjects(app *App) ([]runtime.Object, []string, error) {
 	var objects []runtime.Object
 
 	if app.Labels == nil {
@@ -337,11 +335,11 @@ func CreateK8sObjects(app *spec.App) ([]runtime.Object, []string, error) {
 	return objects, app.ExtraResources, nil
 }
 
-// Transform function if given spec.App data creates the versioned
+// Transform function if given App data creates the versioned
 // kubernetes objects and returns them in list of runtime.Object
-// And if the field in spec.App called 'extraResources' is used
+// And if the field in App called 'extraResources' is used
 // then it returns the filenames mentioned there as list of string
-func Transform(app *spec.App) ([]runtime.Object, []string, error) {
+func Transform(app *App) ([]runtime.Object, []string, error) {
 
 	runtimeObjects, extraResources, err := CreateK8sObjects(app)
 	if err != nil {

--- a/pkg/spec/kubernetes_test.go
+++ b/pkg/spec/kubernetes_test.go
@@ -14,13 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package kubernetes
+package spec
 
 import (
 	"reflect"
 	"testing"
-
-	"github.com/kedgeproject/kedge/pkg/spec"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -30,18 +28,18 @@ import (
 func TestCreateServices(t *testing.T) {
 	tests := []struct {
 		Name    string
-		App     *spec.App
+		App     *App
 		Objects []runtime.Object
 	}{
 		{
 			"Single container specified",
-			&spec.App{
+			&App{
 				Name: "test",
-				PodSpecMod: spec.PodSpecMod{
-					Containers: []spec.Container{{Container: api_v1.Container{Image: "nginx"}}},
+				PodSpecMod: PodSpecMod{
+					Containers: []Container{{Container: api_v1.Container{Image: "nginx"}}},
 				},
-				Services: []spec.ServiceSpecMod{
-					{Name: "test", Ports: []spec.ServicePortMod{{ServicePort: api_v1.ServicePort{Port: 8080}}}},
+				Services: []ServiceSpecMod{
+					{Name: "test", Ports: []ServicePortMod{{ServicePort: api_v1.ServicePort{Port: 8080}}}},
 				},
 			},
 			append(make([]runtime.Object, 0), &api_v1.Service{

--- a/pkg/spec/populators.go
+++ b/pkg/spec/populators.go
@@ -14,21 +14,19 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package kubernetes
+package spec
 
 import (
 	"encoding/json"
 	"fmt"
 	"sort"
 
-	"github.com/kedgeproject/kedge/pkg/spec"
-
 	log "github.com/Sirupsen/logrus"
 	"github.com/pkg/errors"
 	api_v1 "k8s.io/client-go/pkg/api/v1"
 )
 
-func populateProbes(c spec.Container) (spec.Container, error) {
+func populateProbes(c Container) (Container, error) {
 	// check if health and liveness given together
 	if c.Health != nil && (c.ReadinessProbe != nil || c.LivenessProbe != nil) {
 		return c, fmt.Errorf("cannot define field 'health' and " +
@@ -42,16 +40,16 @@ func populateProbes(c spec.Container) (spec.Container, error) {
 	return c, nil
 }
 
-func searchConfigMap(cms []spec.ConfigMapMod, name string) (spec.ConfigMapMod, error) {
+func searchConfigMap(cms []ConfigMapMod, name string) (ConfigMapMod, error) {
 	for _, cm := range cms {
 		if cm.Name == name {
 			return cm, nil
 		}
 	}
-	return spec.ConfigMapMod{}, fmt.Errorf("configMap %q not found", name)
+	return ConfigMapMod{}, fmt.Errorf("configMap %q not found", name)
 }
 
-func getSecretDataKeys(secrets []spec.SecretMod, name string) ([]string, error) {
+func getSecretDataKeys(secrets []SecretMod, name string) ([]string, error) {
 	var dataKeys []string
 	for _, secret := range secrets {
 		if secret.Name == name {
@@ -75,7 +73,7 @@ func getMapKeys(m map[string]string) []string {
 	return d
 }
 
-func convertEnvFromToEnvs(envFrom []api_v1.EnvFromSource, cms []spec.ConfigMapMod, secrets []spec.SecretMod) ([]api_v1.EnvVar, error) {
+func convertEnvFromToEnvs(envFrom []api_v1.EnvFromSource, cms []ConfigMapMod, secrets []SecretMod) ([]api_v1.EnvVar, error) {
 	var envs []api_v1.EnvVar
 
 	// we will iterate on all envFroms
@@ -132,7 +130,7 @@ func convertEnvFromToEnvs(envFrom []api_v1.EnvFromSource, cms []spec.ConfigMapMo
 	return envs, nil
 }
 
-func populateEnvFrom(c spec.Container, cms []spec.ConfigMapMod, secrets []spec.SecretMod) (spec.Container, error) {
+func populateEnvFrom(c Container, cms []ConfigMapMod, secrets []SecretMod) (Container, error) {
 	// now do the env from
 	envs, err := convertEnvFromToEnvs(c.EnvFrom, cms, secrets)
 	if err != nil {
@@ -152,7 +150,7 @@ func populateEnvFrom(c spec.Container, cms []spec.ConfigMapMod, secrets []spec.S
 	return c, nil
 }
 
-func populateContainers(containers []spec.Container, cms []spec.ConfigMapMod, secrets []spec.SecretMod) ([]api_v1.Container, error) {
+func populateContainers(containers []Container, cms []ConfigMapMod, secrets []SecretMod) ([]api_v1.Container, error) {
 	var cnts []api_v1.Container
 
 	for cn, c := range containers {
@@ -181,7 +179,7 @@ func populateContainers(containers []spec.Container, cms []spec.ConfigMapMod, se
 // Since we are automatically creating pvc from
 // root level persistent volume and entry in the container
 // volume mount, we also need to update the pod's volume field
-func populateVolumes(containers []api_v1.Container, volumeClaims []spec.VolumeClaim,
+func populateVolumes(containers []api_v1.Container, volumeClaims []VolumeClaim,
 	volumes []api_v1.Volume) ([]api_v1.Volume, error) {
 	var newPodVols []api_v1.Volume
 

--- a/pkg/spec/util.go
+++ b/pkg/spec/util.go
@@ -14,13 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package kubernetes
+package spec
 
-import (
-	"github.com/kedgeproject/kedge/pkg/spec"
-
-	api_v1 "k8s.io/client-go/pkg/api/v1"
-)
+import api_v1 "k8s.io/client-go/pkg/api/v1"
 
 // This function will search in the pod level volumes
 // and see if the volume with given name is defined
@@ -34,7 +30,7 @@ func isVolumeDefined(volumes []api_v1.Volume, name string) bool {
 }
 
 // search through all the persistent volumes defined in the root level
-func isPVCDefined(volumes []spec.VolumeClaim, name string) bool {
+func isPVCDefined(volumes []VolumeClaim, name string) bool {
 	for _, v := range volumes {
 		if v.Name == name {
 			return true

--- a/pkg/spec/util_test.go
+++ b/pkg/spec/util_test.go
@@ -14,12 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package kubernetes
+package spec
 
 import (
 	"testing"
-
-	"github.com/kedgeproject/kedge/pkg/spec"
 
 	api_v1 "k8s.io/client-go/pkg/api/v1"
 )
@@ -49,7 +47,7 @@ func TestIsVolumeDefined(t *testing.T) {
 }
 
 func TestIsPVCDefined(t *testing.T) {
-	volumes := []spec.VolumeClaim{{Name: "foo"}, {Name: "bar"}, {Name: "baz"}}
+	volumes := []VolumeClaim{{Name: "foo"}, {Name: "bar"}, {Name: "baz"}}
 
 	tests := []struct {
 		Search string


### PR DESCRIPTION
This commit is purely a refactor. All files from
pkg/transform/kubernetes have been moved to pkg/spec. This is
the second part of a bigger effort to consolidate all the
controller specific functions and methods under one package,
i.e. package spec for now, so that we can start defining new
controllers on a codebase that's more suited for extensibility.