### PR TITLE
update glide-vc instructions to use lock file

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -96,7 +96,7 @@ glide update --strip-vendor
 3. Delete all unnecessary files from vendor
 
 ```bash
-glide-vc --only-code --no-tests
+glide-vc --only-code --no-tests --use-lock-file
 ```
 
 3. Commit updated glide files and vendor
@@ -127,7 +127,7 @@ glide update --strip-vendor
 4. Delete all unnecessary files from vendor
 
 ```bash
-glide-vc --only-code --no-tests
+glide-vc --only-code --no-tests --use-lock-file
 ```
 
 5. Commit updated glide files and vendor

--- a/scripts/check-vendor.sh
+++ b/scripts/check-vendor.sh
@@ -45,7 +45,7 @@ function check_glide-vc() {
     if [ $NO_DELETED_FILES -ne 0 ]; then
         echo "ERROR"
         echo "  There are $NO_DELETED_FILES files that can be deleted by glide-vc."
-        echo "  Please run 'glide-vc --only-code --no-tests'"
+        echo "  Please run 'glide-vc --only-code --no-tests --use-lock-file'"
         return 1
     else
         echo "OK"


### PR DESCRIPTION
Glide can go over the entire code base and vendor all the dependencies
that are needed, but glide-vc removes the extra dependencies that tests
need. So asking glide-vc to refer to glide lock file to do removal of
unnecessary things.