### PR TITLE
Fix spelling / grammar error within init.go

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -49,7 +49,7 @@ containers:
 // initCmd represents the version command
 var initCmd = &cobra.Command{
 	Use:   "init",
-	Short: "Intialize Kedge file",
+	Short: "Initialize a Kedge file",
 	Run: func(cmd *cobra.Command, args []string) {
 		data := templateData{Name: name, Image: image, Ports: port}
 		if name != "" && image != "" {


### PR DESCRIPTION
Fixes a minor spelling and grammar mistake.