### PR TITLE
add support for Job controller

### DIFF
--- a/docs/examples/jobs/job.yaml
+++ b/docs/examples/jobs/job.yaml
@@ -1,0 +1,7 @@
+controller: job
+name: pival
+containers:
+- image: perl
+  command: ["perl",  "-Mbignum=bpi", "-wle", "print bpi(2000)"]
+restartPolicy: Never
+parallelism: 3

--- a/docs/file-reference.md
+++ b/docs/file-reference.md
@@ -1,8 +1,7 @@
 # Kedge file reference
 
 Each file defines one micro-service, which forms one `pod` controlled by it's
-controller(right now the default controller is `deployment`).
-
+controller.
 
 A example using all the keys added in Kedge(not all keys from Kubernetes
 API are included):
@@ -71,20 +70,20 @@ defines.
 
 Supported controllers:
 - Deployment
+- Job
 
 Default controller is **Deployment**
 
-## replicas
-
-`replicas: 4`
-
-| **Type** | **Required** |
-|----------|--------------|
-| integer  | no           |
-
-Number of desired pods. This is a pointer to distinguish between explicit zero
-and not specified. Defaults to 1. The valid value can only be a positive number.
-This is an optional field.
+##### Note:
+`activeDeadlineSeconds` is a conflicting field which exists in both, v1.PodSpec
+and batch/v1.JobSpec, and both of these fields exist at the top level of the
+Kedge spec.
+So, whenever `activeDeadlineSeconds` field is set, only JobSpec is populated,
+which means that `activeDeadlineSeconds` is set only for the job and not for the
+pod.
+To populate a pod's `activeDeadlineSeconds`, the user will have to pass this
+field the long way by defining the pod exclusively under
+`job.spec.template.spec.activeDeadlineSeconds`.
 
 
 ## labels
@@ -524,7 +523,7 @@ The file path are relative to the kedge application file.
 This is one of the mechanisms to extend kedge beyond its capabilites to support
 anything in the Kubernetes land.
 
-## Complete example
+## Complete example (deployment)
 
 ```yaml
 name: database
@@ -578,4 +577,16 @@ secrets:
 - name: wordpress
   data:
     MYSQL_ROOT_PASSWORD: YWRtaW4=
+```
+
+## Example (job)
+
+```yaml
+controller: job
+name: pival
+containers:
+- image: perl
+  command: ["perl",  "-Mbignum=bpi", "-wle", "print bpi(2000)"]
+restartPolicy: Never
+parallelism: 3
 ```

--- a/pkg/spec/controller.go
+++ b/pkg/spec/controller.go
@@ -51,6 +51,8 @@ func GetController(data []byte) (ControllerInterface, error) {
 	case "", "deployment":
 		// validate if the user provided input is valid kedge app
 		return &DeploymentSpecMod{}, nil
+	case "job":
+		return &JobSpecMod{}, nil
 	default:
 		return nil, fmt.Errorf("invalid controller: %v", specController.Controller)
 	}

--- a/pkg/spec/controller_test.go
+++ b/pkg/spec/controller_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package spec
 
 import (
-	"encoding/json"
 	"reflect"
 	"testing"
 
@@ -103,9 +102,4 @@ volumeClaims:
 			}
 		})
 	}
-}
-
-func prettyPrintObjects(v interface{}) string {
-	b, _ := json.MarshalIndent(v, "", "  ")
-	return string(b)
 }

--- a/pkg/spec/job.go
+++ b/pkg/spec/job.go
@@ -1,0 +1,142 @@
+/*
+Copyright 2017 The Kedge Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package spec
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/ghodss/yaml"
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	log "github.com/Sirupsen/logrus"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	api_v1 "k8s.io/client-go/pkg/api/v1"
+	batch_v1 "k8s.io/client-go/pkg/apis/batch/v1"
+)
+
+func (job *JobSpecMod) Unmarshal(data []byte) error {
+	err := yaml.Unmarshal(data, &job)
+	if err != nil {
+		return errors.Wrap(err, "could not unmarshal into internal struct")
+	}
+	log.Debugf("object unmarshalled: %#v\n", job)
+	return nil
+}
+
+func (job *JobSpecMod) Fix() error {
+	if err := job.ControllerFields.fixControllerFields(); err != nil {
+		return errors.Wrap(err, "unable to fix ControllerFields")
+	}
+	return nil
+}
+
+func (job *JobSpecMod) Transform() ([]runtime.Object, []string, error) {
+
+	runtimeObjects, extraResources, err := job.CreateK8sObjects()
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "failed to create Kubernetes objects")
+	}
+
+	j, err := job.CreateK8sController()
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "failed to create Kubernetes Job controller")
+	}
+
+	if j != nil {
+		runtimeObjects = append(runtimeObjects, j)
+		log.Debug("job: &s, job: &s\n", j.Name, spew.Sprint(j))
+	}
+
+	// TODO: abstract out following code, but holding back since would be great
+	// to make scheme controller specific
+	if len(runtimeObjects) == 0 {
+		return nil, nil, errors.New("No runtime objects created, possibly because not enough input data was passed")
+	}
+
+	scheme, err := GetScheme()
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "unable to get scheme")
+	}
+
+	for _, runtimeObject := range runtimeObjects {
+		if err := SetGVK(runtimeObject, scheme); err != nil {
+			return nil, nil, errors.Wrap(err, "unable to set Group, Version and Kind for generated Kubernetes resources")
+		}
+	}
+
+	return runtimeObjects, extraResources, nil
+}
+
+func (job *JobSpecMod) CreateK8sController() (*batch_v1.Job, error) {
+
+	// We need to error out if both, job.PodSpec and job.JobSpec are empty
+	if job.isJobSpecPodSpecEmpty() {
+		log.Debug("Both, job.PodSpec and job.JobSpec are empty, not enough data to create a job.")
+		return nil, nil
+	}
+
+	// Checking if PodSpec is specified at multiple levels
+	if job.isMultiplePodSpecSpecified() {
+		return nil, fmt.Errorf("Pod can't be specfied in two places. Use top level PodSpec or template.spec (JobSpec.Template.Spec) not both")
+	}
+
+	jobSpec := job.JobSpec
+
+	if !reflect.DeepEqual(job.PodSpec, api_v1.PodSpec{}) {
+		jobSpec.Template.Spec = job.PodSpec
+	}
+
+	// activeDeadlineSeconds is a conflicting field which exists in both,
+	// v1.PodSpec and batch/v1.JobSpec, and both of these fields exist at the
+	// top level of JobSpecMod.
+	// So, whenever activeDeadlineSeconds field is passed, we will only
+	// populate the JobSpec and not the PodSpec.
+	// To populate PodSpec's activeDeadlineSeconds, the user will have to pass
+	// this field the long way by defining PodSpec exclusively.
+	if job.ActiveDeadlineSeconds != nil {
+		jobSpec.ActiveDeadlineSeconds = job.ActiveDeadlineSeconds
+	}
+
+	return &batch_v1.Job{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name:   job.Name,
+			Labels: job.Labels,
+		},
+		Spec: jobSpec,
+	}, nil
+}
+
+func (job *JobSpecMod) Validate() error {
+
+	// validate controller fields
+	if err := job.ControllerFields.validateControllerFields(); err != nil {
+		return errors.Wrap(err, "unable to validate controller fields")
+	}
+
+	return nil
+}
+
+func (job *JobSpecMod) isJobSpecPodSpecEmpty() bool {
+	return reflect.DeepEqual(job.PodSpec, api_v1.PodSpec{}) && reflect.DeepEqual(job.JobSpec, batch_v1.JobSpec{})
+}
+
+func (job *JobSpecMod) isMultiplePodSpecSpecified() bool {
+	return !(reflect.DeepEqual(job.JobSpec.Template.Spec, api_v1.PodSpec{}) || reflect.DeepEqual(job.PodSpec, api_v1.PodSpec{}))
+}

--- a/pkg/spec/job_test.go
+++ b/pkg/spec/job_test.go
@@ -1,0 +1,125 @@
+/*
+Copyright 2017 The Kedge Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package spec
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	api_v1 "k8s.io/client-go/pkg/api/v1"
+	batch_v1 "k8s.io/client-go/pkg/apis/batch/v1"
+)
+
+func TestJobSpecMod_CreateK8sController(t *testing.T) {
+	tests := []struct {
+		name          string
+		jobSpecMod    *JobSpecMod
+		kubernetesJob *batch_v1.Job
+		success       bool
+	}{
+		{
+			name: "both PodSpec and JobSpec are empty, no Job should be created",
+			jobSpecMod: &JobSpecMod{
+				ControllerFields: ControllerFields{
+					Controller: "job",
+					Secrets: []SecretMod{
+						{
+							Name: "secret",
+							Secret: api_v1.Secret{
+								StringData: map[string]string{
+									"testData": "testValue",
+								},
+							},
+						},
+					},
+				},
+			},
+			kubernetesJob: nil,
+			success:       true,
+		},
+		{
+			name: "ActiveDeadlineSeconds is specified, make sure it's only populated for JobSpec and not for PodSpec",
+			jobSpecMod: &JobSpecMod{
+				ControllerFields: ControllerFields{
+					Name:       "testJob",
+					Controller: "job",
+					PodSpecMod: PodSpecMod{
+						PodSpec: api_v1.PodSpec{
+							Containers: []api_v1.Container{
+								{
+									Name:  "testContainer",
+									Image: "testImage",
+								},
+							},
+						},
+					},
+				},
+
+				ActiveDeadlineSeconds: getInt64Addr(20),
+				JobSpec: batch_v1.JobSpec{
+					Parallelism: getInt32Addr(2),
+				},
+			},
+			kubernetesJob: &batch_v1.Job{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Name: "testJob",
+				},
+				Spec: batch_v1.JobSpec{
+					Parallelism:           getInt32Addr(2),
+					ActiveDeadlineSeconds: getInt64Addr(20),
+					Template: api_v1.PodTemplateSpec{
+						Spec: api_v1.PodSpec{
+							Containers: []api_v1.Container{
+								{
+									Name:  "testContainer",
+									Image: "testImage",
+								},
+							},
+						},
+					},
+				},
+			},
+			success: true,
+		},
+	}
+
+	for _, test := range tests {
+
+		t.Run(test.name, func(t *testing.T) {
+
+			kJob, err := test.jobSpecMod.CreateK8sController()
+
+			switch test.success {
+			case true:
+				if err != nil {
+					t.Errorf("Expected test to pass but got an error -\n%v", err)
+				}
+			case false:
+				if err == nil {
+					t.Errorf("For the input -\n%v\nexpected test to fail, but test passed", spew.Sprint(test.jobSpecMod))
+				}
+			}
+
+			if !reflect.DeepEqual(test.kubernetesJob, kJob) {
+
+				t.Errorf("Expected Kubernetes Job to be -\n%v\nBut got -\n%v", prettyPrintObjects(test.kubernetesJob), prettyPrintObjects(kJob))
+			}
+		})
+	}
+}

--- a/pkg/spec/resources.go
+++ b/pkg/spec/resources.go
@@ -117,6 +117,46 @@ func fixContainers(containers []Container, appName string) ([]Container, error) 
 	return containers, nil
 }
 
+func (cf *ControllerFields) fixControllerFields() error {
+
+	var err error
+
+	// fix Services
+	cf.Services, err = fixServices(cf.Services, cf.Name)
+	if err != nil {
+		return errors.Wrap(err, "Unable to fix services")
+	}
+
+	// fix VolumeClaims
+	cf.VolumeClaims, err = fixVolumeClaims(cf.VolumeClaims, cf.Name)
+	if err != nil {
+		return errors.Wrap(err, "Unable to fix persistentVolume")
+	}
+
+	// fix configMaps
+	cf.ConfigMaps, err = fixConfigMaps(cf.ConfigMaps, cf.Name)
+	if err != nil {
+		return errors.Wrap(err, "unable to fix configMaps")
+	}
+
+	cf.Containers, err = fixContainers(cf.Containers, cf.Name)
+	if err != nil {
+		return errors.Wrap(err, "unable to fix containers")
+	}
+
+	cf.InitContainers, err = fixContainers(cf.InitContainers, cf.Name)
+	if err != nil {
+		return errors.Wrap(err, "unable to fix init-containers")
+	}
+
+	cf.Secrets, err = fixSecrets(cf.Secrets, cf.Name)
+	if err != nil {
+		return errors.Wrap(err, "unable to fix secrets")
+	}
+
+	return nil
+}
+
 // Transform
 
 func (app *ControllerFields) getLabels() map[string]string {
@@ -381,6 +421,17 @@ func validateVolumeClaims(vcs []VolumeClaim) error {
 			return fmt.Errorf("duplicate entry of volume claim %q", vc.Name)
 		}
 	}
+
+	return nil
+}
+
+func (app *ControllerFields) validateControllerFields() error {
+
+	// validate volumeclaims
+	if err := validateVolumeClaims(app.VolumeClaims); err != nil {
+		return errors.Wrap(err, "error validating volume claims")
+	}
+
 	return nil
 }
 

--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -18,6 +18,7 @@ package spec
 
 import (
 	api_v1 "k8s.io/client-go/pkg/api/v1"
+	batch_v1 "k8s.io/client-go/pkg/apis/batch/v1"
 	ext_v1beta1 "k8s.io/client-go/pkg/apis/extensions/v1beta1"
 )
 
@@ -171,6 +172,20 @@ type DeploymentSpecMod struct {
 	ControllerFields `json:",inline"`
 	// k8s: io.k8s.kubernetes.pkg.apis.apps.v1beta1.DeploymentSpec
 	ext_v1beta1.DeploymentSpec `json:",inline"`
+}
+
+// JobSpecMod is Kedge's extension of Kubernetes JobSpec and allows
+// defining a complete kedge application
+// kedgeSpec: io.kedge.JobSpecMod
+type JobSpecMod struct {
+	ControllerFields `json:",inline"`
+	// k8s: io.k8s.kubernetes.pkg.apis.batch.v1.JobSpec
+	batch_v1.JobSpec `json:",inline"`
+	// Optional duration in seconds relative to the startTime that the job may be active
+	// before the system tries to terminate it; value must be positive integer
+	// This only sets ActiveDeadlineSeconds in JobSpec, not PodSpec
+	// +optional
+	ActiveDeadlineSeconds *int64 `json:"activeDeadlineSeconds,conflicting,omitempty"`
 }
 
 type Controller struct {

--- a/pkg/spec/spec_test.go
+++ b/pkg/spec/spec_test.go
@@ -43,6 +43,7 @@ func TestConflictingFields(t *testing.T) {
 		&ConfigMapMod{},
 		&PodSpecMod{},
 		&DeploymentSpecMod{},
+		&JobSpecMod{},
 	}
 
 	for _, inputStruct := range structsToTest {


### PR DESCRIPTION
- [x] Check ActiveDeadlineSeconds behavior
- [x] Add docs

---
```
    This commit adds the Kubernetes Job controller support to Kedge.
    
    For the code part, pkg/spec/job.go which contains the related
    methods for the Job controller.
    Some part has been abstracted out of pkg/spec/deployment.go to
    pkg/spec/util.go to enable reuse by different controllers.
    
    Documentation and examples have been added.
```