### PR TITLE
change from DeploymentSpec to DeploymentSpecMod

### DIFF
--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -163,7 +163,7 @@ type ControllerFields struct {
 
 // DeploymentSpecMod is Kedge's extension of Kubernetes DeploymentSpec and allows
 // defining a complete kedge application
-// kedgeSpec: io.kedge.DeploymentSpec
+// kedgeSpec: io.kedge.DeploymentSpecMod
 type DeploymentSpecMod struct {
 	ControllerFields `json:",inline"`
 	// k8s: io.k8s.kubernetes.pkg.apis.apps.v1beta1.DeploymentSpec


### PR DESCRIPTION
Right now since the name conflicts with the upstream DeploymentSpec
so when the tool `openapi2jsonschema` is run it overwrites one with
another. So to avoid the naming conflict changing the tag same, so
the final output file name also changes.