### PR TITLE
Fix order of controller functions

### DIFF
--- a/pkg/spec/deployment.go
+++ b/pkg/spec/deployment.go
@@ -41,6 +41,16 @@ func (deployment *DeploymentSpecMod) Unmarshal(data []byte) error {
 	return nil
 }
 
+func (deployment *DeploymentSpecMod) Validate() error {
+
+	// validate volumeclaims
+	if err := validateVolumeClaims(deployment.VolumeClaims); err != nil {
+		return errors.Wrap(err, "error validating volume claims")
+	}
+
+	return nil
+}
+
 // TODO: abstract out this code when more controllers are added
 func (deployment *DeploymentSpecMod) Fix() error {
 
@@ -166,14 +176,4 @@ func (deployment *DeploymentSpecMod) CreateK8sController() (*ext_v1beta1.Deploym
 		},
 		Spec: deploymentSpec,
 	}, nil
-}
-
-func (deployment *DeploymentSpecMod) Validate() error {
-
-	// validate volumeclaims
-	if err := validateVolumeClaims(deployment.VolumeClaims); err != nil {
-		return errors.Wrap(err, "error validating volume claims")
-	}
-
-	return nil
 }


### PR DESCRIPTION
Rearranges Validate to match the functions within `controller.go`

```go
if err := kController.Unmarshal(data); err != nil {
        return nil, nil, errors.Wrap(err, "unable to unmarshal data")
}

if err := kController.Validate(); err != nil {
        return nil, nil, errors.Wrap(err, "unable to validate data")
}

if err := kController.Fix(); err != nil {
        return nil, nil, errors.Wrap(err, "unable to fix data")
}

ros, extraResources, err := kController.Transform()
if err != nil {
        return nil, nil, errors.Wrap(err, "unable to transform data")
}
```