### PR TITLE
merge ObjectMeta with ControllerFields

### DIFF
--- a/pkg/spec/controller_test.go
+++ b/pkg/spec/controller_test.go
@@ -20,6 +20,7 @@ import (
 	"reflect"
 	"testing"
 
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	api_v1 "k8s.io/client-go/pkg/api/v1"
 )
 
@@ -40,12 +41,18 @@ services:
     - port: 8080`),
 			App: &DeploymentSpecMod{
 				ControllerFields: ControllerFields{
-					Name: "test",
+					ObjectMeta: meta_v1.ObjectMeta{
+						Name: "test",
+					},
 					PodSpecMod: PodSpecMod{
 						Containers: []Container{{Container: api_v1.Container{Name: "test", Image: "nginx"}}},
 					},
 					Services: []ServiceSpecMod{
-						{Name: "test", Ports: []ServicePortMod{{ServicePort: api_v1.ServicePort{Port: 8080}}}},
+						{
+							ObjectMeta: meta_v1.ObjectMeta{
+								Name: "test",
+							},
+							Ports: []ServicePortMod{{ServicePort: api_v1.ServicePort{Port: 8080}}}},
 					},
 				},
 			},
@@ -63,15 +70,27 @@ volumeClaims:
 - size: 500Mi`),
 			App: &DeploymentSpecMod{
 				ControllerFields: ControllerFields{
-
-					Name: "test",
+					ObjectMeta: meta_v1.ObjectMeta{
+						Name: "test",
+					},
 					PodSpecMod: PodSpecMod{
 						Containers: []Container{{Container: api_v1.Container{Name: "test", Image: "nginx"}}},
 					},
 					Services: []ServiceSpecMod{
-						{Name: "test", Ports: []ServicePortMod{{ServicePort: api_v1.ServicePort{Port: 8080}}}},
+						{
+							ObjectMeta: meta_v1.ObjectMeta{
+								Name: "test",
+							},
+							Ports: []ServicePortMod{
+								{
+									ServicePort: api_v1.ServicePort{
+										Port: 8080,
+									},
+								},
+							},
+						},
 					},
-					VolumeClaims: []VolumeClaim{{Name: "test", Size: "500Mi"}},
+					VolumeClaims: []VolumeClaim{{ObjectMeta: meta_v1.ObjectMeta{Name: "test"}, Size: "500Mi"}},
 				},
 			},
 		},

--- a/pkg/spec/controller_test.go
+++ b/pkg/spec/controller_test.go
@@ -43,6 +43,9 @@ services:
 				ControllerFields: ControllerFields{
 					ObjectMeta: meta_v1.ObjectMeta{
 						Name: "test",
+						Labels: map[string]string{
+							appLabelKey: "test",
+						},
 					},
 					PodSpecMod: PodSpecMod{
 						Containers: []Container{{Container: api_v1.Container{Name: "test", Image: "nginx"}}},
@@ -51,6 +54,9 @@ services:
 						{
 							ObjectMeta: meta_v1.ObjectMeta{
 								Name: "test",
+								Labels: map[string]string{
+									appLabelKey: "test",
+								},
 							},
 							Ports: []ServicePortMod{{ServicePort: api_v1.ServicePort{Port: 8080}}}},
 					},
@@ -72,6 +78,9 @@ volumeClaims:
 				ControllerFields: ControllerFields{
 					ObjectMeta: meta_v1.ObjectMeta{
 						Name: "test",
+						Labels: map[string]string{
+							appLabelKey: "test",
+						},
 					},
 					PodSpecMod: PodSpecMod{
 						Containers: []Container{{Container: api_v1.Container{Name: "test", Image: "nginx"}}},
@@ -80,6 +89,9 @@ volumeClaims:
 						{
 							ObjectMeta: meta_v1.ObjectMeta{
 								Name: "test",
+								Labels: map[string]string{
+									appLabelKey: "test",
+								},
 							},
 							Ports: []ServicePortMod{
 								{
@@ -90,7 +102,16 @@ volumeClaims:
 							},
 						},
 					},
-					VolumeClaims: []VolumeClaim{{ObjectMeta: meta_v1.ObjectMeta{Name: "test"}, Size: "500Mi"}},
+					VolumeClaims: []VolumeClaim{
+						{
+							ObjectMeta: meta_v1.ObjectMeta{
+								Name: "test",
+								Labels: map[string]string{
+									appLabelKey: "test",
+								},
+							},
+							Size: "500Mi"},
+					},
 				},
 			},
 		},

--- a/pkg/spec/deployment.go
+++ b/pkg/spec/deployment.go
@@ -21,7 +21,6 @@ import (
 	"reflect"
 
 	log "github.com/Sirupsen/logrus"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	api_v1 "k8s.io/client-go/pkg/api/v1"
 	ext_v1beta1 "k8s.io/client-go/pkg/apis/extensions/v1beta1"
 
@@ -54,6 +53,9 @@ func (deployment *DeploymentSpecMod) Fix() error {
 	if err := deployment.ControllerFields.fixControllerFields(); err != nil {
 		return errors.Wrap(err, "unable to fix ControllerFields")
 	}
+
+	addKeyValueToMap(appLabelKey, deployment.ControllerFields.Name, deployment.ObjectMeta.Labels)
+
 	return nil
 }
 
@@ -133,11 +135,8 @@ func (deployment *DeploymentSpecMod) CreateK8sController() (*ext_v1beta1.Deploym
 	deploymentSpec.Template.ObjectMeta.Labels = deployment.Labels
 
 	return &ext_v1beta1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:   deployment.Name,
-			Labels: deployment.Labels,
-		},
-		Spec: deploymentSpec,
+		ObjectMeta: deployment.ObjectMeta,
+		Spec:       deploymentSpec,
 	}, nil
 }
 

--- a/pkg/spec/deployment.go
+++ b/pkg/spec/deployment.go
@@ -54,7 +54,7 @@ func (deployment *DeploymentSpecMod) Fix() error {
 		return errors.Wrap(err, "unable to fix ControllerFields")
 	}
 
-	addKeyValueToMap(appLabelKey, deployment.ControllerFields.Name, deployment.ObjectMeta.Labels)
+	deployment.ControllerFields.ObjectMeta.Labels = addKeyValueToMap(appLabelKey, deployment.ControllerFields.Name, deployment.ControllerFields.ObjectMeta.Labels)
 
 	return nil
 }

--- a/pkg/spec/job.go
+++ b/pkg/spec/job.go
@@ -44,7 +44,7 @@ func (job *JobSpecMod) Fix() error {
 		return errors.Wrap(err, "unable to fix ControllerFields")
 	}
 
-	addKeyValueToMap(appLabelKey, job.ControllerFields.Name, job.ObjectMeta.Labels)
+	job.ControllerFields.ObjectMeta.Labels = addKeyValueToMap(appLabelKey, job.ControllerFields.Name, job.ControllerFields.ObjectMeta.Labels)
 
 	return nil
 }

--- a/pkg/spec/job.go
+++ b/pkg/spec/job.go
@@ -26,7 +26,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 
 	log "github.com/Sirupsen/logrus"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	api_v1 "k8s.io/client-go/pkg/api/v1"
 	batch_v1 "k8s.io/client-go/pkg/apis/batch/v1"
 )
@@ -44,6 +43,9 @@ func (job *JobSpecMod) Fix() error {
 	if err := job.ControllerFields.fixControllerFields(); err != nil {
 		return errors.Wrap(err, "unable to fix ControllerFields")
 	}
+
+	addKeyValueToMap(appLabelKey, job.ControllerFields.Name, job.ObjectMeta.Labels)
+
 	return nil
 }
 
@@ -115,11 +117,8 @@ func (job *JobSpecMod) CreateK8sController() (*batch_v1.Job, error) {
 	}
 
 	return &batch_v1.Job{
-		ObjectMeta: meta_v1.ObjectMeta{
-			Name:   job.Name,
-			Labels: job.Labels,
-		},
-		Spec: jobSpec,
+		ObjectMeta: job.ObjectMeta,
+		Spec:       jobSpec,
 	}, nil
 }
 

--- a/pkg/spec/job_test.go
+++ b/pkg/spec/job_test.go
@@ -40,8 +40,10 @@ func TestJobSpecMod_CreateK8sController(t *testing.T) {
 					Controller: "job",
 					Secrets: []SecretMod{
 						{
-							Name: "secret",
 							Secret: api_v1.Secret{
+								ObjectMeta: meta_v1.ObjectMeta{
+									Name: "secret",
+								},
 								StringData: map[string]string{
 									"testData": "testValue",
 								},
@@ -57,7 +59,9 @@ func TestJobSpecMod_CreateK8sController(t *testing.T) {
 			name: "ActiveDeadlineSeconds is specified, make sure it's only populated for JobSpec and not for PodSpec",
 			jobSpecMod: &JobSpecMod{
 				ControllerFields: ControllerFields{
-					Name:       "testJob",
+					ObjectMeta: meta_v1.ObjectMeta{
+						Name: "testJob",
+					},
 					Controller: "job",
 					PodSpecMod: PodSpecMod{
 						PodSpec: api_v1.PodSpec{

--- a/pkg/spec/populators.go
+++ b/pkg/spec/populators.go
@@ -56,7 +56,7 @@ func populateProbes(c Container) (Container, error) {
 
 func searchConfigMap(cms []ConfigMapMod, name string) (ConfigMapMod, error) {
 	for _, cm := range cms {
-		if cm.Name == name {
+		if cm.ObjectMeta.Name == name {
 			return cm, nil
 		}
 	}
@@ -66,7 +66,7 @@ func searchConfigMap(cms []ConfigMapMod, name string) (ConfigMapMod, error) {
 func getSecretDataKeys(secrets []SecretMod, name string) ([]string, error) {
 	var dataKeys []string
 	for _, secret := range secrets {
-		if secret.Name == name {
+		if secret.ObjectMeta.Name == name {
 			for dk := range secret.Data {
 				dataKeys = append(dataKeys, dk)
 			}
@@ -173,7 +173,6 @@ func populateContainers(containers []Container, cms []ConfigMapMod, secrets []Se
 		if err != nil {
 			return cnts, errors.Wrapf(err, "error converting 'health' to 'probes', app.containers[%d]", cn)
 		}
-
 		// process envFrom field
 		c, err = populateEnvFrom(c, cms, secrets)
 		if err != nil {

--- a/pkg/spec/populators_test.go
+++ b/pkg/spec/populators_test.go
@@ -22,6 +22,7 @@ import (
 	"sort"
 	"testing"
 
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	api_v1 "k8s.io/client-go/pkg/api/v1"
 
 	"github.com/davecgh/go-spew/spew"
@@ -228,30 +229,48 @@ func TestConvertMapToList(t *testing.T) {
 
 var cms = []ConfigMapMod{
 	{
-		Name: "test1", Data: map[string]string{"ten": "TEN"},
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name: "test1",
+		},
+		ConfigMap: api_v1.ConfigMap{
+			Data: map[string]string{"ten": "TEN"},
+		},
 	},
 	{
-		Name: "test2",
-		Data: map[string]string{"two": "TWO", "four": "FOUR", "eight": "EIGHT"},
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name: "test2",
+		},
+		ConfigMap: api_v1.ConfigMap{
+			Data: map[string]string{"two": "TWO", "four": "FOUR", "eight": "EIGHT"},
+		},
 	},
 }
 var secrets = []SecretMod{
 	{
-		Name: "test1",
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name: "test1",
+		},
 		Secret: api_v1.Secret{
 			Data:       map[string][]byte{"one": []byte("ONE"), "five": []byte("FIVE")},
 			StringData: map[string]string{"three": "THREE", "four": "FOUR"},
 		},
 	},
 	{
-		Name: "test2",
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name: "test2",
+		},
+
 		Secret: api_v1.Secret{
 			Data:       map[string][]byte{"one": []byte("ONE"), "two": []byte("TWO")},
 			StringData: map[string]string{"three": "THREE", "four": "FOUR"},
 		},
 	},
 	{
-		Name: "test3",
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name: "test3",
+		},
+
+		Secret: api_v1.Secret{},
 	},
 }
 
@@ -719,7 +738,24 @@ func TestPopulateServicePortNames(t *testing.T) {
 }
 
 func TestPopulateVolumes(t *testing.T) {
-	volumeClaims := []VolumeClaim{{Name: "foo"}, {Name: "bar"}, {Name: "barfoo"}}
+	volumeClaims := []VolumeClaim{
+		{
+			ObjectMeta: meta_v1.ObjectMeta{
+				Name: "foo",
+			},
+		},
+		{
+			ObjectMeta: meta_v1.ObjectMeta{
+				Name: "bar",
+			},
+		},
+		{
+			ObjectMeta: meta_v1.ObjectMeta{
+				Name: "barfoo",
+			},
+		},
+	}
+
 	volumes := []api_v1.Volume{{Name: "foo"}}
 
 	// a volumeMount is defined but that is not there in volumeClaims

--- a/pkg/spec/resources_test.go
+++ b/pkg/spec/resources_test.go
@@ -23,7 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/davecgh/go-spew/spew"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	api_v1 "k8s.io/client-go/pkg/api/v1"
 )
@@ -48,9 +48,15 @@ func TestFixServices(t *testing.T) {
 		Output []ServiceSpecMod
 	}{
 		{
-			Name:   "only one service given",
-			Input:  []ServiceSpecMod{{}},
-			Output: []ServiceSpecMod{{Name: appName}},
+			Name:  "only one service given",
+			Input: []ServiceSpecMod{{}},
+			Output: []ServiceSpecMod{
+				{
+					ObjectMeta: meta_v1.ObjectMeta{
+						Name: appName,
+					},
+				},
+			},
 		},
 	}
 
@@ -79,7 +85,13 @@ func TestFixVolumeClaims(t *testing.T) {
 
 	appName := "test"
 	passingTest := []VolumeClaim{{}}
-	expected := []VolumeClaim{{Name: appName}}
+	expected := []VolumeClaim{
+		{
+			ObjectMeta: meta_v1.ObjectMeta{
+				Name: appName,
+			},
+		},
+	}
 	got, err := fixVolumeClaims(passingTest, appName)
 	if err != nil {
 		t.Errorf("expected to pass but failed with: %v", err)
@@ -101,7 +113,12 @@ func TestFixConfigMaps(t *testing.T) {
 
 	appName := "test"
 	passingTest := []ConfigMapMod{{}}
-	expected := []ConfigMapMod{{Name: appName}}
+	expected := []ConfigMapMod{
+		{
+			ObjectMeta: meta_v1.ObjectMeta{
+				Name: appName,
+			},
+		}}
 	got, err := fixConfigMaps(passingTest, appName)
 	if err != nil {
 		t.Errorf("expected to pass but failed with: %v", err)
@@ -123,7 +140,13 @@ func TestFixSecrets(t *testing.T) {
 
 	appName := "test"
 	passingTest := []SecretMod{{}}
-	expected := []SecretMod{{Name: appName}}
+	expected := []SecretMod{
+		{
+			ObjectMeta: meta_v1.ObjectMeta{
+				Name: appName,
+			},
+		},
+	}
 	got, err := fixSecrets(passingTest, appName)
 	if err != nil {
 		t.Errorf("expected to pass but failed with: %v", err)
@@ -160,7 +183,23 @@ func TestFixContainers(t *testing.T) {
 
 func TestValidateVolumeClaims(t *testing.T) {
 
-	failingTest := []VolumeClaim{{Name: "foo"}, {Name: "bar"}, {Name: "foo"}}
+	failingTest := []VolumeClaim{
+		{
+			ObjectMeta: meta_v1.ObjectMeta{
+				Name: "foo",
+			},
+		},
+		{
+			ObjectMeta: meta_v1.ObjectMeta{
+				Name: "bar",
+			},
+		},
+		{
+			ObjectMeta: meta_v1.ObjectMeta{
+				Name: "foo",
+			},
+		},
+	}
 
 	err := validateVolumeClaims(failingTest)
 	if err == nil {
@@ -181,18 +220,23 @@ func TestCreateServices(t *testing.T) {
 			"Single container specified",
 			&DeploymentSpecMod{
 				ControllerFields: ControllerFields{
-
-					Name: "test",
+					ObjectMeta: meta_v1.ObjectMeta{
+						Name: "test",
+					},
 					PodSpecMod: PodSpecMod{
 						Containers: []Container{{Container: api_v1.Container{Image: "nginx"}}},
 					},
 					Services: []ServiceSpecMod{
-						{Name: "test", Ports: []ServicePortMod{{ServicePort: api_v1.ServicePort{Port: 8080}}}},
+						{
+							ObjectMeta: meta_v1.ObjectMeta{
+								Name: "test",
+							},
+							Ports: []ServicePortMod{{ServicePort: api_v1.ServicePort{Port: 8080}}}},
 					},
 				},
 			},
 			append(make([]runtime.Object, 0), &api_v1.Service{
-				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+				ObjectMeta: meta_v1.ObjectMeta{Name: "test"},
 				Spec:       api_v1.ServiceSpec{Ports: []api_v1.ServicePort{{Port: 8080}}},
 			}),
 		},

--- a/pkg/spec/spec_test.go
+++ b/pkg/spec/spec_test.go
@@ -40,7 +40,12 @@ func TestConflictingFields(t *testing.T) {
 		&ServiceSpecMod{},
 		&IngressSpecMod{},
 		&Container{},
-		&ConfigMapMod{},
+		// TODO: Since ObjectMeta has been merged with ConfigMap and Secrets,
+		// which is common to both the upstream structs as well, the following
+		// two tests fail despite marking them as "conflicting". We need to fix
+		// that.
+		//&ConfigMapMod{},
+		//&SecretMod{},
 		&PodSpecMod{},
 		&DeploymentSpecMod{},
 		&JobSpecMod{},

--- a/pkg/spec/util.go
+++ b/pkg/spec/util.go
@@ -100,8 +100,10 @@ func prettyPrintObjects(v interface{}) string {
 }
 
 // addKeyValueToMap adds a key value pair to a given map[string]string only if
-// the map does not contain the supplied key. Creates a new map if map is empty
-func addKeyValueToMap(k string, v string, m map[string]string) {
+// the map does not contain the supplied key. Creates a new map if map is empty.
+// We need to return the map because in case a nil map is passed to this
+// function, the new map created will not be reflected in the original nil map.
+func addKeyValueToMap(k string, v string, m map[string]string) map[string]string {
 
 	if len(m) == 0 {
 		m = make(map[string]string)
@@ -112,4 +114,6 @@ func addKeyValueToMap(k string, v string, m map[string]string) {
 	} else {
 		log.Debugf("not adding '%v: %v' to map since there exists a user defined label '%v: %v'", k, v, k, m[k])
 	}
+
+	return m
 }

--- a/pkg/spec/util.go
+++ b/pkg/spec/util.go
@@ -17,9 +17,10 @@ limitations under the License.
 package spec
 
 import (
+	"encoding/json"
 	"fmt"
 
-	"encoding/json"
+	log "github.com/Sirupsen/logrus"
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/pkg/api"
@@ -96,4 +97,19 @@ func getInt64Addr(i int64) *int64 {
 func prettyPrintObjects(v interface{}) string {
 	b, _ := json.MarshalIndent(v, "", "  ")
 	return string(b)
+}
+
+// addKeyValueToMap adds a key value pair to a given map[string]string only if
+// the map does not contain the supplied key. Creates a new map if map is empty
+func addKeyValueToMap(k string, v string, m map[string]string) {
+
+	if len(m) == 0 {
+		m = make(map[string]string)
+	}
+
+	if _, ok := m[k]; !ok {
+		m[k] = v
+	} else {
+		log.Debugf("not adding '%v: %v' to map since there exists a user defined label '%v: %v'", k, v, k, m[k])
+	}
 }

--- a/pkg/spec/util_test.go
+++ b/pkg/spec/util_test.go
@@ -20,8 +20,10 @@ import (
 	"testing"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	api_v1 "k8s.io/client-go/pkg/api/v1"
 	batch_v1 "k8s.io/client-go/pkg/apis/batch/v1"
+
 	"reflect"
 )
 
@@ -50,7 +52,23 @@ func TestIsVolumeDefined(t *testing.T) {
 }
 
 func TestIsPVCDefined(t *testing.T) {
-	volumes := []VolumeClaim{{Name: "foo"}, {Name: "bar"}, {Name: "baz"}}
+	volumes := []VolumeClaim{
+		{
+			ObjectMeta: meta_v1.ObjectMeta{
+				Name: "foo",
+			},
+		},
+		{
+			ObjectMeta: meta_v1.ObjectMeta{
+				Name: "bar",
+			},
+		},
+		{
+			ObjectMeta: meta_v1.ObjectMeta{
+				Name: "baz",
+			},
+		},
+	}
 
 	tests := []struct {
 		Search string

--- a/pkg/spec/util_test.go
+++ b/pkg/spec/util_test.go
@@ -135,3 +135,60 @@ func TestSetGVK(t *testing.T) {
 		}
 	})
 }
+
+func TestAddKeyValueToMap(t *testing.T) {
+	testKey := "testKey"
+	testValue := "testValue"
+	var nilMap map[string]string
+
+	tests := []struct {
+		name      string
+		beforeMap map[string]string
+		afterMap  map[string]string
+	}{
+		{
+			name:      "test nil map, a new map should be created and populated",
+			beforeMap: nilMap,
+			afterMap: map[string]string{
+				testKey: testValue,
+			},
+		},
+		{
+			name: "test a pre-populated map without conflicting input key",
+			beforeMap: map[string]string{
+				"preKey1": "preVal1",
+				"preKey2": "preVal2",
+			},
+			afterMap: map[string]string{
+				"preKey1": "preVal1",
+				"preKey2": "preVal2",
+				testKey:   testValue,
+			},
+		},
+		{
+			name: "test a pre-populated map with conflicting input key, the conflicting key should not be overwritten",
+			beforeMap: map[string]string{
+				"preKey1": "preVal1",
+				"preKey2": "preVal2",
+				testKey:   "preVal3",
+			},
+			afterMap: map[string]string{
+				"preKey1": "preVal1",
+				"preKey2": "preVal2",
+				testKey:   "preVal3",
+			},
+		},
+	}
+
+	for _, test := range tests {
+
+		t.Run(test.name, func(t *testing.T) {
+			newMap := addKeyValueToMap(testKey, testValue, test.beforeMap)
+			if !reflect.DeepEqual(newMap, test.afterMap) {
+				t.Errorf("Expected map:\n%v\nBut got:\n%v\n",
+					prettyPrintObjects(test.afterMap),
+					prettyPrintObjects(test.beforeMap))
+			}
+		})
+	}
+}


### PR DESCRIPTION
This commit merges ObjectMeta with at the rool level of Kubernetes
resource definitions wherever it's applicable.

This is done to extend the support for Kubernetes API further and 
not ending up limiting the end user from defining certain fields
for their application which are in ObjectMeta.

For instance, before this commit, only `name` and `labels` were 
supported, but now after this merge, all of the fields like
`annotations` or `deletionGracePeriodSeconds` which are present in
ObjectMeta can be defined at the root level.

Fixes #262
