### PR TITLE
Script to display live output from e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,15 +71,15 @@ test-unit:
 test-e2e:
 
 ifneq ($(and $(PARALLEL),$(TIMEOUT)),)
-	go test -parallel=$(PARALLEL) -timeout=$(TIMEOUT) -v github.com/kedgeproject/kedge/tests/e2e
+	./tests/e2e/run_e2e.sh -p $(PARALLEL) -t $(TIMEOUT)
 else
 ifdef PARALLEL
-	go test -parallel=$(PARALLEL) -v github.com/kedgeproject/kedge/tests/e2e
+	./tests/e2e/run_e2e.sh -p $(PARALLEL)
 else
 ifdef TIMEOUT
-	go test -timeout=$(TIMEOUT) -v github.com/kedgeproject/kedge/tests/e2e
+	./tests/e2e/run_e2e.sh -t $(TIMEOUT)
 else
-	go test -v github.com/kedgeproject/kedge/tests/e2e
+	./tests/e2e/run_e2e.sh
 endif
 endif
 endif

--- a/tests/e2e/run_e2e.sh
+++ b/tests/e2e/run_e2e.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# Copyright 2017 The Kedge Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+run_command="go test"
+
+while getopts ":p:t:" opt; do
+    case $opt in
+	p ) PARALLEL=$OPTARG;;
+	r ) TIMEOUT=$OPTARG;;
+    esac
+done
+
+if [ -n "$PARALLEL" ]; then
+    run_command+=" -parallel=$PARALLEL"
+fi
+
+if [ -n "$TIMEOUT" ]; then
+    run_command+=" -timeout=$TIMEOUT"
+fi
+
+run_command+=" -v github.com/kedgeproject/kedge/tests/e2e"
+
+# Run e2e tests
+eval $run_command &
+TEST_PID=$!
+
+# Watch the pods being generated
+kubectl get po --all-namespaces -w &
+KUBE_PID=$!
+
+# Kill processes once done
+(while kill -0 $TEST_PID; do sleep 5; done) && kill $KUBE_PID


### PR DESCRIPTION
Currently, when e2e tests are run, the output is displayed only after the test run is complete. This is a known limitation of `go tests`.

With this simple script, we run make test-e2e and `kubectl get po --all-namespaces -w` in the background, and terminate the process once the test run is complete, helping us keep a watch on the individual tests while they are being run.