### PR TITLE
Add support for environment variable substitution

### DIFF
--- a/docs/file-reference.md
+++ b/docs/file-reference.md
@@ -590,3 +590,41 @@ containers:
 restartPolicy: Never
 parallelism: 3
 ```
+
+
+# Variables
+You can use variables anywhere in the Kedge file. Variable names are enclosed
+in double square brackets (`[[ variable_name ]]`).
+For example `[[ IMAGE_NAME ]]` will be replaced with value of environment variable `$IMAGE_NAME`
+
+## Example
+```yaml
+# nginx.yaml
+
+name: nginx
+containers:
+- image: nginx:[[ NGINX_VERSION ]]
+services:
+- name: nginx
+  ports:
+  - port: 8080
+    targetPort: 80
+```
+
+Now you can call Kedge and define `NGINX_VERSION` variable.
+```
+NGINX_VERSION=1.13 kedge apply -f nginx.yaml
+```
+The string `[[ NGINX_VERSION ]]` will be replaced with `1.13`.
+Effecting Kedge file will look as following:
+```
+name: nginx
+containers:
+- image: nginx:1.13
+services:
+- name: nginx
+  type: ClusterIP
+  ports:
+  - port: 8080
+    targetPort: 80
+```

--- a/pkg/cmd/kubernetes.go
+++ b/pkg/cmd/kubernetes.go
@@ -47,7 +47,15 @@ func CreateKubernetesArtifacts(paths []string, generate bool, args ...string) er
 
 	for _, input := range inputs {
 
-		ros, includeResources, err := spec.CoreOperations(input.data)
+		// Substitute variables
+		// We do this on raw Kedge file before unmarshalling, because it would be
+		// complicated to go through all different go structs.
+		data, err := SubstituteVariables(input.data)
+		if err != nil {
+			return errors.Wrap(err, "failed to replace variables")
+		}
+
+		ros, includeResources, err := spec.CoreOperations(data)
 		if err != nil {
 			return errors.Wrap(err, "unable to perform controller operations")
 		}


### PR DESCRIPTION
You can use environment variables in you Kedge files. Expression is `[[ variable_name ]]`.

fixes #224 

TODO:
- ~~move variable substitution logic from pkg/cmd/util.go to its own package~~
- [x] documentation


> ~~move variable substitution logic from pkg/cmd/util.go to its own package~~

I'm keeping this as it is, for now. We need clean up whole `pkg/cmd` package. Created https://github.com/kedgeproject/kedge/issues/301 


