### PR TITLE
fix(spec): add optional tag in struct fields

### DIFF
--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -57,9 +57,11 @@ type ServiceSpecMod struct {
 	// The list of ports that are exposed by this service. More info:
 	// https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
 	// ref: io.kedge.ServicePort
+	// +optional
 	Ports []ServicePortMod `json:"ports,conflicting"`
 	// The list of portMappings, where each portMapping allows specifying port,
 	// targetPort and protocol in the format '<port>:<targetPort>/<protocol>'
+	// +optional
 	PortMappings []string `json:"portMappings,omitempty"`
 }
 


### PR DESCRIPTION
`portMappings` was added as an option to ports in services which is
option to `ports`, initially `ports` was a compulsory field but with
`portMappings` addition, either field can be specified. So adding
`+optional` tag to both fields.