### PR TITLE
add coverage test to normal test runs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ _testmain.go
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+**/.coverprofile
 
 #
 # VIM SPECIFIC

--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ endif
 
 # Run all tests
 .PHONY: test
-test: test-dep validate test-unit
+test: test-dep validate test-unit test-unit-cover
 
 # Tests that are run on travs-ci
 .PHONY: travis-tests


### PR DESCRIPTION
Coverage test is only in travis tests but not locally
so add it to the normal test suite.

Fixes https://github.com/kedgeproject/kedge/issues/333