### PR TITLE
fix(travis): don't test on go1.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,11 +11,9 @@ env:
 
 matrix:
   include:
-    - go: 1.6
     - go: 1.7
     - go: 1.8
-  allow_failures:
-    - go: 1.6
+    - go: 1.9
 
 install:
   - true


### PR DESCRIPTION
We don't need to test on golang 1.6 since even centos has moved
to golang 1.8.

```console
# cat /etc/redhat-release 
CentOS Linux release 7.4.1708 (Core) 

# go version
go version go1.8.3 linux/amd64
```