### PR TITLE
fix(kedge create): add flag `--save-config`

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -34,7 +34,7 @@ var createCmd = &cobra.Command{
 			os.Exit(-1)
 		}
 
-		kubectlCommand := []string{"create"}
+		kubectlCommand := []string{"create", "--save-config"}
 
 		// Only setting the namespace flag to kubectl when --namespace is passed
 		// explicitly by the user


### PR DESCRIPTION
By enabling this flag for `kubectl create` by default, the
configuration of current object will be saved in its annotation.
Otherwise, the annotation will be unchanged. This flag is useful
when you want to perform `kedge apply` on this object in the future.

Fixes https://github.com/kedgeproject/kedge/issues/322