### PR TITLE
fix error message for creating DeploymentConfig

### DIFF
--- a/pkg/spec/deploymentconfig.go
+++ b/pkg/spec/deploymentconfig.go
@@ -115,7 +115,7 @@ func (deploymentConfig *DeploymentConfigSpecMod) Transform() ([]runtime.Object, 
 	// Create the DeploymentConfig controller!
 	deploy, err := deploymentConfig.createOpenShiftController()
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "failed to create Kubernetes Deployment controller")
+		return nil, nil, errors.Wrap(err, "failed to create DeploymentConfig controller")
 	}
 
 	// adding controller objects


### PR DESCRIPTION
Previously, the error message would be related to a Kubernetes
Deployment.

This commit fixes and rewords the message for the DeploymentConfig
controller.