### PR TITLE
remove Labels from ControllerFields

### DIFF
--- a/pkg/spec/types.go
+++ b/pkg/spec/types.go
@@ -138,11 +138,6 @@ type SecretMod struct {
 // ControllerFields are the common fields in every controller Kedge supports
 type ControllerFields struct {
 	Controller string `json:"controller,omitempty"`
-	// Map of string keys and values that can be used to organize and categorize
-	// (scope and select) objects. May match selectors of replication controllers
-	// and services. More info: http://kubernetes.io/docs/user-guide/labels
-	// +optional
-	Labels map[string]string `json:"labels,omitempty,conflicting"`
 	// List of volume that should be mounted on the pod.
 	// ref: io.kedge.VolumeClaim
 	// +optional


### PR DESCRIPTION
This commit removes Labels field from ControllerFields struct
in pkg/types.go.

We do not require Labels because ControllerFields already has
(meta)v1.ObjectMeta struct embedded into it which contains the
Labels field.