### PR TITLE
set default replicas as 1 in DeploymentConfig

### DIFF
--- a/docs/examples/deploymentconfig/deploymentconfig.yaml
+++ b/docs/examples/deploymentconfig/deploymentconfig.yaml
@@ -1,6 +1,5 @@
 controller: deploymentconfig
 name: httpd
-replicas: 2
 containers:
 - image: centos/httpd
 services:

--- a/pkg/spec/deploymentconfig_test.go
+++ b/pkg/spec/deploymentconfig_test.go
@@ -26,6 +26,82 @@ import (
 	api_v1 "k8s.io/kubernetes/pkg/api/v1"
 )
 
+func TestFixDeploymentConfig(t *testing.T) {
+	tests := []struct {
+		name           string
+		input          *DeploymentConfigSpecMod
+		expectedOutput *DeploymentConfigSpecMod
+	}{
+		{
+			name:  "No replicas passed at input, expected 1",
+			input: &DeploymentConfigSpecMod{},
+			expectedOutput: &DeploymentConfigSpecMod{
+				ControllerFields: ControllerFields{
+					ObjectMeta: meta_v1.ObjectMeta{
+						Labels: map[string]string{
+							appLabelKey: "",
+						},
+					},
+				},
+				DeploymentConfigSpec: os_deploy_v1.DeploymentConfigSpec{
+					Replicas: 1,
+				},
+				Replicas: getInt32Addr(1),
+			},
+		},
+		{
+			name: "replicas set to 0 by the end user, expected 0",
+			input: &DeploymentConfigSpecMod{
+				Replicas: getInt32Addr(0),
+			},
+			expectedOutput: &DeploymentConfigSpecMod{
+				ControllerFields: ControllerFields{
+					ObjectMeta: meta_v1.ObjectMeta{
+						Labels: map[string]string{
+							appLabelKey: "",
+						},
+					},
+				},
+				DeploymentConfigSpec: os_deploy_v1.DeploymentConfigSpec{
+					Replicas: 0,
+				},
+				Replicas: getInt32Addr(0),
+			},
+		},
+		{
+			name: "replicas set to 2 by the end user, expected 2",
+			input: &DeploymentConfigSpecMod{
+				Replicas: getInt32Addr(2),
+			},
+			expectedOutput: &DeploymentConfigSpecMod{
+				ControllerFields: ControllerFields{
+					ObjectMeta: meta_v1.ObjectMeta{
+						Labels: map[string]string{
+							appLabelKey: "",
+						},
+					},
+				},
+				DeploymentConfigSpec: os_deploy_v1.DeploymentConfigSpec{
+					Replicas: 2,
+				},
+				Replicas: getInt32Addr(2),
+			},
+		},
+	}
+
+	for _, test := range tests {
+
+		t.Run(test.name, func(t *testing.T) {
+			test.input.fixDeploymentConfig()
+			if !reflect.DeepEqual(test.input, test.expectedOutput) {
+				t.Errorf("Expected output to be:\n%v\nBut got:\n%v\n",
+					prettyPrintObjects(test.expectedOutput),
+					prettyPrintObjects(test.input))
+			}
+		})
+	}
+}
+
 func TestDeploymentConfigSpecMod_CreateOpenShiftController(t *testing.T) {
 	tests := []struct {
 		name                    string

--- a/pkg/spec/types.go
+++ b/pkg/spec/types.go
@@ -201,4 +201,13 @@ type JobSpecMod struct {
 type DeploymentConfigSpecMod struct {
 	ControllerFields                  `json:",inline"`
 	os_deploy_v1.DeploymentConfigSpec `json:",inline"`
+
+	// Replicas is the number of desired replicas.
+	// We need to add this field here despite being in v1.DeploymentConfigSpec
+	// because the one in v1.DeploymentConfigSpec has the type as int32, which
+	// does not let us check if the set value is 0, is it set by the user or not
+	// since this field's value with default to 0. We need the default value as
+	// 1. Hence, we need to check if the user has set it or not.Making the type
+	// *int32 helps us do it, followed by substitution later on.
+	Replicas *int32 `json:"replicas,omitempty"`
 }


### PR DESCRIPTION
Setting no value for the "replicas" field in a DeploymentConfig
sets the value as 0, while we should be setting this value as 1.

This commit fixes that.

Fixes #357