### PR TITLE
add support for OpenShift Routes

### DIFF
--- a/docs/examples/routes/README.md
+++ b/docs/examples/routes/README.md
@@ -1,0 +1,28 @@
+# Using Routes
+
+`routes` is a field at the root level of the Kedge spec, which can be used
+to define OpenShift routes.
+
+An OpenShift route is a way to expose a service by giving it an
+externally-reachable hostname.
+More info at https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/routes.html
+
+Much like other resource definitions in Kedge, routes have been implemented
+by merging `RouteSpec` and `ObjectMeta`, which would mean that you can
+define fields like `name` and the rest of the RouteSpec at the same level.
+
+An example would be -
+```yaml
+name: webroute
+host: httpd-web.192.168.42.69.nip.io
+to:
+  kind: Service
+  name: httpd
+  weight: 100
+wildcardPolicy: None
+```
+
+## Ref
+
+- [What are OpenShift routes](https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/routes.html) 
+- [OpenShift v1.Route API](https://docs.openshift.org/latest/rest_api/apis-route.openshift.io/v1.Route.html)

--- a/docs/examples/routes/httpd.yml
+++ b/docs/examples/routes/httpd.yml
@@ -1,0 +1,12 @@
+name: httpd
+containers:
+- image: bitnami/nginx
+services:
+- name: httpd
+  type: NodePort
+  portMappings:
+  - 8080:8080
+routes:
+- to:
+    kind: Service
+    name: httpd

--- a/docs/file-reference.md
+++ b/docs/file-reference.md
@@ -423,6 +423,38 @@ More info about Probe: https://kubernetes.io/docs/api-reference/v1.6/#probe-v1-c
 
 The name of the Ingress.
 
+## routes
+
+```yaml
+routes:
+- <routeObject>
+- <routeObject>
+```
+
+| **Type**                                  | **Required** |
+|-------------------------------------------|--------------|
+| array of [route object](#routeObject) | no           |
+
+
+### routeObject
+
+```yaml
+routes:
+- name: <string>
+  <Route Spec>
+```
+
+Example:
+```yaml
+name: webroute
+to:
+  kind: Service
+  name: httpd
+```
+
+Each `route` object is OpenShift's `RouteSpec` and `ObjectMeta` field.
+More info: https://docs.openshift.org/latest/rest_api/apis-route.openshift.io/v1.Route.html#object-schema
+
 ## secrets
 
 ```yaml

--- a/pkg/spec/deploymentconfig.go
+++ b/pkg/spec/deploymentconfig.go
@@ -51,39 +51,8 @@ func (deploymentConfig *DeploymentConfigSpecMod) Validate() error {
 // TODO: abstract out this code when more controllers are added
 func (deploymentConfig *DeploymentConfigSpecMod) Fix() error {
 
-	var err error
-
-	// fix deploymentConfig.Services
-	deploymentConfig.Services, err = fixServices(deploymentConfig.Services, deploymentConfig.Name)
-	if err != nil {
-		return errors.Wrap(err, "Unable to fix services")
-	}
-
-	// fix deploymentConfig.VolumeClaims
-	deploymentConfig.VolumeClaims, err = fixVolumeClaims(deploymentConfig.VolumeClaims, deploymentConfig.Name)
-	if err != nil {
-		return errors.Wrap(err, "Unable to fix persistentVolume")
-	}
-
-	// fix deploymentConfig.configMaps
-	deploymentConfig.ConfigMaps, err = fixConfigMaps(deploymentConfig.ConfigMaps, deploymentConfig.Name)
-	if err != nil {
-		return errors.Wrap(err, "unable to fix configMaps")
-	}
-
-	deploymentConfig.Containers, err = fixContainers(deploymentConfig.Containers, deploymentConfig.Name)
-	if err != nil {
-		return errors.Wrap(err, "unable to fix containers")
-	}
-
-	deploymentConfig.InitContainers, err = fixContainers(deploymentConfig.InitContainers, deploymentConfig.Name)
-	if err != nil {
-		return errors.Wrap(err, "unable to fix init-containers")
-	}
-
-	deploymentConfig.Secrets, err = fixSecrets(deploymentConfig.Secrets, deploymentConfig.Name)
-	if err != nil {
-		return errors.Wrap(err, "unable to fix secrets")
+	if err := deploymentConfig.ControllerFields.fixControllerFields(); err != nil {
+		return errors.Wrap(err, "unable to fix ControllerFields")
 	}
 
 	// Fix DeploymentConfig

--- a/pkg/spec/types.go
+++ b/pkg/spec/types.go
@@ -18,6 +18,7 @@ package spec
 
 import (
 	os_deploy_v1 "github.com/openshift/origin/pkg/deploy/apis/apps/v1"
+	os_route_v1 "github.com/openshift/origin/pkg/route/apis/route/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	api_v1 "k8s.io/kubernetes/pkg/api/v1"
 	batch_v1 "k8s.io/kubernetes/pkg/apis/batch/v1"
@@ -70,6 +71,12 @@ type ServiceSpecMod struct {
 type IngressSpecMod struct {
 	// k8s: io.k8s.kubernetes.pkg.apis.extensions.v1beta1.IngressSpec
 	ext_v1beta1.IngressSpec `json:",inline"`
+	// k8s: io.k8s.kubernetes.pkg.apis.meta.v1.ObjectMeta
+	meta_v1.ObjectMeta `json:",inline"`
+}
+
+type RouteSpecMod struct {
+	os_route_v1.RouteSpec `json:",inline"`
 	// k8s: io.k8s.kubernetes.pkg.apis.meta.v1.ObjectMeta
 	meta_v1.ObjectMeta `json:",inline"`
 }
@@ -154,6 +161,10 @@ type ControllerFields struct {
 	// ref: io.kedge.IngressSpec
 	// +optional
 	Ingresses []IngressSpecMod `json:"ingresses,omitempty"`
+	// List of OpenShift Routes
+	// ref: io.kedge.RouteSpec
+	// +optional
+	Routes []RouteSpecMod `json:"routes,omitempty"`
 	// List of Kubernetes Secrets
 	// ref: io.kedge.SecretSpec
 	// +optional

--- a/pkg/spec/util.go
+++ b/pkg/spec/util.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	api_v1 "k8s.io/kubernetes/pkg/api/v1"
 	//kapi "k8s.io/kubernetes/pkg/api/v1"
+	os_route_v1 "github.com/openshift/origin/pkg/route/apis/route/v1"
 	batch_v1 "k8s.io/kubernetes/pkg/apis/batch/v1"
 )
 
@@ -65,12 +66,20 @@ func GetScheme() (*runtime.Scheme, error) {
 	// Initializing the scheme with the core v1 api
 	scheme := api.Scheme
 
+	// TODO: find a way where we don't have to add all the subsequent schemes
+	// to the v1 scheme, instead we should be able to have different scheme for
+	// different controllers
+
 	// Adding the batch scheme to support Jobs
-	// TODO: find a way where we don't have to add batch/v1 to the v1 scheme,
-	// instead we should be able to have different scheme for different controllers
 	if err := batch_v1.AddToScheme(scheme); err != nil {
 		return nil, errors.Wrap(err, "unable to add 'batch' to scheme")
 	}
+
+	// Adding the route scheme to support OpenShift routes
+	if err := os_route_v1.AddToScheme(scheme); err != nil {
+		return nil, errors.Wrap(err, "unable to add 'routes' to scheme")
+	}
+
 	return scheme, nil
 }
 


### PR DESCRIPTION
This commit adds support for defining OpenShift routes in a Kedge
file.

Routes can be defined like the following at the root level of a
Kedge file

```yaml
routes:
- name: route1
  host: route1-myproject.192.168.42.69.nip.io
  port:
    targetPort: 8080
  to:
    kind: Service
    name: httpd
```

This is implemented by essentially merging RouteSpec and ObjectMeta
and adding an array of the resulting struct at the root level under
the field "routes"

Adds docs, tests.

Fixes #238