### PR TITLE
add OpenShift Apps scheme for DeploymentConfig

### DIFF
--- a/pkg/spec/deploymentconfig_test.go
+++ b/pkg/spec/deploymentconfig_test.go
@@ -133,10 +133,6 @@ func TestDeploymentConfigSpecMod_CreateOpenShiftController(t *testing.T) {
 				},
 			},
 			deployment: &os_deploy_v1.DeploymentConfig{
-				TypeMeta: meta_v1.TypeMeta{
-					Kind:       "DeploymentConfig",
-					APIVersion: "v1",
-				},
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name: "testJob",
 				},
@@ -186,10 +182,6 @@ func TestDeploymentConfigSpecMod_CreateOpenShiftController(t *testing.T) {
 				},
 			},
 			deployment: &os_deploy_v1.DeploymentConfig{
-				TypeMeta: meta_v1.TypeMeta{
-					Kind:       "DeploymentConfig",
-					APIVersion: "v1",
-				},
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name: "testJob",
 				},

--- a/pkg/spec/util.go
+++ b/pkg/spec/util.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	api_v1 "k8s.io/kubernetes/pkg/api/v1"
 	//kapi "k8s.io/kubernetes/pkg/api/v1"
+	os_deploy_v1 "github.com/openshift/origin/pkg/deploy/apis/apps/v1"
 	os_route_v1 "github.com/openshift/origin/pkg/route/apis/route/v1"
 	batch_v1 "k8s.io/kubernetes/pkg/apis/batch/v1"
 )
@@ -69,6 +70,11 @@ func GetScheme() (*runtime.Scheme, error) {
 	// TODO: find a way where we don't have to add all the subsequent schemes
 	// to the v1 scheme, instead we should be able to have different scheme for
 	// different controllers
+
+	// Adding the apps scheme to support DeploymentConfig
+	if err := os_deploy_v1.AddToScheme(scheme); err != nil {
+		return nil, errors.Wrap(err, "unable to add 'apps' (OpenShift) to scheme")
+	}
 
 	// Adding the batch scheme to support Jobs
 	if err := batch_v1.AddToScheme(scheme); err != nil {


### PR DESCRIPTION
This commit adds OpenShift's Apps scheme to support
DeploymentConfig.

Prior to this commit, the TypeMeta for a DeploymentConfig had to
be hard coded, but now it's derived from the generated scheme
after addition of the Apps scheme.

The code in Transform() method in pkg/spec/deploymentconfig.go is
also refactored to leverage the scheme and be aligned with the
code in pkg/spec/deployment.go

Fixes #349