### PR TITLE
Divide ingress example to 2 parts

### DIFF
--- a/docs/examples/endpoint/README.md
+++ b/docs/examples/endpoint/README.md
@@ -1,0 +1,41 @@
+# Endpoint
+
+See the following snippet from [web.yaml](web.yaml).
+
+```yaml
+services:
+- name: wordpress
+  ports:
+  - port: 8080
+    targetPort: 80
+    endpoint: minikube.local
+```
+
+Services here is an extension of [`service` spec](https://kubernetes.io/docs/api-reference/v1.6/#servicespec-v1-core),
+such that the `ServicePort` struct is extended with an `endpoint` field.  So if
+you want a service to be exposed via an ingress set the `endpoint` field in the
+format `ingress_host/ingress_path`.
+
+When the `generate` command is run against this file, we can see that an ingress
+resource is populated automatically with the following parameters -
+
+```yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  creationTimestamp: null
+  labels:
+    app: web
+  name: wordpress-8080
+spec:
+  rules:
+  - host: minikube.local
+    http:
+      paths:
+      - backend:
+          serviceName: wordpress
+          servicePort: 8080
+        path: /foo
+status:
+  loadBalancer: {}
+```

--- a/docs/examples/endpoint/db.yaml
+++ b/docs/examples/endpoint/db.yaml
@@ -1,0 +1,16 @@
+name: database
+containers:
+- image: mariadb:10
+  env:
+  - name: MYSQL_ROOT_PASSWORD
+    value: rootpasswd
+  - name: MYSQL_DATABASE
+    value: wordpress
+  - name: MYSQL_USER
+    value: wordpress
+  - name: MYSQL_PASSWORD
+    value: wordpress
+services:
+- name: database
+  ports:
+  - port: 3306

--- a/docs/examples/endpoint/web.yaml
+++ b/docs/examples/endpoint/web.yaml
@@ -16,13 +16,4 @@ services:
   ports:
   - port: 8080
     targetPort: 80
-ingresses:
-- name: root-ingress
-  rules:
-  - host: minikube.external
-    http:
-      paths:
-      - backend:
-          serviceName: wordpress
-          servicePort: 8080
-        path: /
+    endpoint: minikube.local  # endpoint: <URL>/<Path>

--- a/docs/examples/ingress/README.md
+++ b/docs/examples/ingress/README.md
@@ -1,46 +1,12 @@
 # Ingress
 
-See the following snippet from [web.yaml](web.yaml).
+An Ingress is a collection of rules that allow inbound connections to
+reach the cluster services.
 
-```yaml
-services:
-- name: wordpress
-  ports:
-  - port: 8080
-    targetPort: 80
-    endpoint: minikube.local
-```
+Like the way most of the Kedge constructs are, for an Ingress resource
+ObjectMeta and IngressSpec have been merged at the same YAML level.
 
-Services here is an extension of [`service` spec](https://kubernetes.io/docs/api-reference/v1.6/#servicespec-v1-core),
-such that the `ServicePort` struct is extended with an `endpoint` field.  So if
-you want a service to be exposed via an ingress set the `endpoint` field in the
-format `ingress_host/ingress_path`.
-
-When the `generate` command is run against this file, we can see that an ingress
-resource is populated automatically with the following parameters -
-
-```yaml
-apiVersion: extensions/v1beta1
-kind: Ingress
-metadata:
-  creationTimestamp: null
-  labels:
-    app: web
-  name: wordpress-8080
-spec:
-  rules:
-  - host: minikube.local
-    http:
-      paths:
-      - backend:
-          serviceName: wordpress
-          servicePort: 8080
-        path: /foo
-status:
-  loadBalancer: {}
-```
-
-A valid `Ingress` resource can also be specified at the rool level of the spec,
+A valid `Ingress` resource can be specified at the rool level of the spec,
 in a field called `ingresses` like we see in the [web.yaml](web.yaml):
 
 ```yaml


### PR DESCRIPTION
Currently, it's a bit confusing that we exhibit the ingresses
field and endpoint shortcut in one file itself.

This commit breaks the ingress example to 2 parts.

- docs/examples/ingress/ contains the example for only the
ingresses field.
- docs/examples/endpoint/ contains the example exhibiting the
endpoint shortcut field.

This makes it much clearer during demos/testing behavior.