### PR TITLE
fix(e2e tests): make test compile

### DIFF
--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -15,8 +15,8 @@ import (
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/tools/clientcmd"
-	v1 "k8s.io/kubernetes/pkg/api/v1"
 )
 
 /*


### PR DESCRIPTION
e2e tests failed due to wrong import of the test dependency and
since the test starting script was buggy, the tests seemed to pass
even if they were failing, now the import has been fixed.

Fixes https://github.com/kedgeproject/kedge/issues/371