### PR TITLE
always populate service port name

### DIFF
--- a/pkg/spec/populators.go
+++ b/pkg/spec/populators.go
@@ -29,12 +29,10 @@ import (
 
 func populateServicePortNames(serviceName string, servicePorts []api_v1.ServicePort) {
 	// auto populate port names if more than 1 port specified
-	if len(servicePorts) > 1 {
-		for i := range servicePorts {
-			// Only populate if the port name is not already specified
-			if len(servicePorts[i].Name) == 0 {
-				servicePorts[i].Name = serviceName + "-" + strconv.FormatInt(int64(servicePorts[i].Port), 10)
-			}
+	for i := range servicePorts {
+		// Only populate if the port name is not already specified
+		if len(servicePorts[i].Name) == 0 {
+			servicePorts[i].Name = serviceName + "-" + strconv.FormatInt(int64(servicePorts[i].Port), 10)
 		}
 	}
 }

--- a/pkg/spec/populators_test.go
+++ b/pkg/spec/populators_test.go
@@ -217,6 +217,7 @@ func TestPopulateServicePortNames(t *testing.T) {
 			},
 			outputServicePorts: []api_v1.ServicePort{
 				{
+					Name: fmt.Sprintf("%v-%v", serviceName, 8080),
 					Port: 8080,
 				},
 			},

--- a/pkg/spec/resources_test.go
+++ b/pkg/spec/resources_test.go
@@ -609,7 +609,7 @@ func TestCreateServices(t *testing.T) {
 			},
 			append(make([]runtime.Object, 0), &api_v1.Service{
 				ObjectMeta: meta_v1.ObjectMeta{Name: "test"},
-				Spec:       api_v1.ServiceSpec{Ports: []api_v1.ServicePort{{Port: 8080}}},
+				Spec:       api_v1.ServiceSpec{Ports: []api_v1.ServicePort{{Port: 8080, Name: "test-8080"}}},
 			}),
 		},
 	}


### PR DESCRIPTION
Service port name was only populated when, there were more than one
ports in the service, but now the port names will be always be
populated if none given by the user.

When you create a service with just one service and expose it with a
OpenShift route, and later in time if you add one more port to the
exposed service, the OpenShift route will send traffic to all the
ports of service. To avoid that naming the port from the first time
is necessary.

Fixes https://github.com/kedgeproject/kedge/issues/323