### PR TITLE
few small updates to travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ deploy:
   key: "${BINTRAY_KEY}"
   skip_cleanup: true
   on:
-    branch: "**"
+    branch: "master"
     go: 1.8
 
 after_success:

--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ test-unit-cover:
 	go test -i -race -cover $(PKGS)
 	# go test doesn't support colleting coverage across multiple packages,
 	# generate go test commands using go list and run go test for every package separately
-	go list -f '"go test -race -cover -v -coverprofile={{.Dir}}/.coverprofile {{.ImportPath}}"' github.com/kedgeproject/kedge/...  | grep -v "vendor" | grep -v "e2e" | xargs -L 1 -P4 sh -c
+	go list -f '"go test -race -cover -coverprofile={{.Dir}}/.coverprofile {{.ImportPath}}"' github.com/kedgeproject/kedge/...  | grep -v "vendor" | grep -v "e2e" | xargs -L 1 -P4 sh -c
 
 # Update vendoring
 # Vendoring is a bit messy right now

--- a/scripts/generate-bintray-json.sh
+++ b/scripts/generate-bintray-json.sh
@@ -3,6 +3,36 @@
 DATE=`date --iso-8601=date`
 TIME=`date --iso-8601=seconds`
 
+
+# generate ./bin/info.txt
+# this file contains information about what files were build and whan
+
+commit_id=$(git rev-parse HEAD)
+origin=$(git config --get remote.origin.url)
+
+cat > "./bin/info.txt" <<EOF
+date: ${TIME}
+build_from: ${origin}
+commit_id: ${commit_id}
+files:
+EOF
+
+for f in $(ls -1 ./bin/* | grep -v info.txt); do
+  sha256sum=$(sha256sum $f | cut -d ' ' -f 1);
+  name=$(basename $f)
+  updated_on=$(stat -c %y $f)
+  cat >> "./bin/info.txt" <<EOF
+  - name: ${name}"
+    sha256sum: ${sha256sum}"
+    updated_on: ${updated_on}
+EOF
+done
+
+
+
+# generate .bintray.json
+# this file contains all information on what will be upload to bintray
+# for mor info: https://docs.travis-ci.com/user/deployment/bintray/
 cat > "./.bintray.json" <<EOF
 {
     "package": {


### PR DESCRIPTION
This PR contains a couple of fixes for travis-ci. Two of them are one-liners, it doesn't make sense to create separate pr for every one of them.

- upload binaries only from master branch
- don't run go test in verbose mode (it just pollutes output with unnecessary information, if test fails it will show all the necessary info)
- generate and upload info.txt to bintray so it is possible to get information about what was uploaded