### PR TITLE
Add TOC + notice

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,1 @@
+NOTE: These docs files are best viewed at [kedgeproject.org](http://kedgeproject.org)

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,5 +1,8 @@
 # Development Guide
 
+* TOC
+{:toc}
+
 ## Building Kedge
 
 Read about building kedge [here](https://github.com/kedgeproject/kedge#building).

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1,11 +1,7 @@
 # User Guide
 
-- CLI
-  - [`create`](#kedge-create)
-  - [`generate`](#kedge-generate)
-  - [`delete`](#kedge-delete)
-  - [`version`](#kedge-version)  
-  - [`init`](#kedge-init)
+* TOC
+{:toc}
 
 ## Kedge Create
 


### PR DESCRIPTION
Adds a TOC to development.md and user-guide.md as well as adds a notice
when viewing /docs on GitHub that the documentation is best viewed on
the website.