### PR TITLE
Update README.md and add installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,29 +2,24 @@
 
 [![Semaphore Build Status Widget]][Semaphore Build Status] [![Travis Build Status Widget]][Travis Build Status] [![Coverage Status Widget]][Coverage Status] [![GoDoc Widget]][GoDoc] [![GoReportCard Widget]][GoReportCardResult] [![Slack Widget]][Slack] 
 
-## What is Kedge?
-
 ![logo](/docs/images/logo.png)
+
+----
 
 Kedge is a simple, easy and declarative way to define and deploy applications to Kubernetes by writing very concise application definitions.
 
 Key features and goals include:
 
+  - __An extension of Kubernetes:__ Use pre-existing definitions such as Pod or Container within your artifact file.
   - __Declarative:__ Declarative definitions specifying developer's intent.
   - __Simplicity:__ Using a simple and concise specification that is easy to understand and define.
   - __Concise:__ Define just the necessary bits and Kedge will do the rest. Kedge will interprolate and pick the best defaults for your application to run on Kubernetes.
   - __Multi-container environments:__ Define your containers, services and applications in one simple file, or split them into multiple files.
   - __Familiar structure:__ Using a familiar YAML structure as Kubernetes, it's easy to pick-up and understand Kedge.
-  - __Built on top of Kubernetes Pod definition:__ Leverages Kuberenetes Pod definition (PodSpec) and avoids leaky abstractions.
 
+----
 
-## Project status
-
-We are a very evolving project with high velocity, we have listed a [file reference specification](docs/file-reference.md) as well as document our RFC's and changes as [GitHub issues](https://github.com/kedgeproject/kedge/issues).
-
-Check out our [roadmap](ROADMAP.md) as we push towards a __0.4.0__ release.
-
-## Using Kedge
+## To start using Kedge
 
 ### Installing
 
@@ -47,84 +42,23 @@ __Windows:__
 
 Download from [GitHub](https://github.com/kedgeproject/kedge/releases/download/v0.4.0/kedge-windows-amd64.exe) and add the binary to your PATH.
 
-### Installing the latest binary (master)
+A more thorough installation guide is [also available](http://kedgeproject.org/installation).
 
-You can download latest binary (built on each master PR merge) for [Linux (amd64)][Bintray Latest Linux], [macOS (darwin)][Bintray Latest macOS] or [Windows (amd64)][Bintray Latest Windows] from [Bintray](https://bintray.com):
+### Using Kedge
 
-__Linux and macOS:__
+Try our [quick start guide](http://kedgeproject.org/quickstart/).
 
-```sh
-# Linux 
-curl -L https://dl.bintray.com/kedgeproject/kedge/latest/kedge-linux-amd64 -o kedge
+Go through our [file reference](http://kedgeproject.org/file-reference).
 
-# macOS
-curl -L https://dl.bintray.com/kedgeproject/kedge/latest/kedge-darwin-amd64 -o kedge
-
-chmod +x kedge
-sudo mv ./kedge /usr/local/bin/kedge
-```
-
-__Windows:__
-
-Download from [Bintray](https://dl.bintray.com/kedgeproject/kedge/latest/kedge-windows-amd64.exe) and add the binary to your PATH.
-
-__You can also download and build Kedge via Go:__
-
-```sh
-go get github.com/kedgeproject/kedge
-```
-
-### Trying it out
-
-We have an [extensive list of examples](docs/examples) to check out, but the simplest of them all is a [standard http example](https://raw.githubusercontent.com/kedgeproject/kedge/master/docs/examples/simplest/httpd.yaml) with [minikube](https://github.com/kubernetes/minikube):
-
-```yaml
-name: httpd
-containers:
-- image: centos/httpd
-services:
-- name: httpd
-  type: NodePort
-  ports:
-  - port: 8080
-    targetPort: 80
-```
-
-We can now create this example on the Kubernetes cluster:
-
-```sh
-$ kedge create -f httpd.yaml
-deployment "httpd" created
-service "httpd" created
-```
-
-And access it:
-
-```sh
-$ kubectl get po,deploy,svc
-NAME                        READY     STATUS    RESTARTS   AGE
-po/httpd-3617778768-ddlrs   1/1       Running   0          1m
-
-NAME           DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
-deploy/httpd   1         1         1            1           1m
-
-NAME             CLUSTER-IP   EXTERNAL-IP   PORT(S)          AGE
-svc/httpd        10.0.0.187   <nodes>       8080:31385/TCP   1m
-svc/kubernetes   10.0.0.1     <none>        443/TCP          18h
-
-$ minikube service httpd
-Opening kubernetes service default/httpd in default browser...
-```
-
-Our examples range from [as simple as you can get](docs/examples/simplest) to [every possible key you can use](docs/examples/all). More can be found in the [docs/examples](docs/examples) directory.
+Then go further with our pre-existing [examples](https://github.com/kedgeproject/kedge/tree/master/examples).
 
 ## Community, Discussion, Contribution, and Support
 
-__Contributing:__ Kedge is an evolving project and contributions are happily welcome. Feel free to open up an issue or even a PR. Read our [contributing guide](CONTRIBUTING.md) for more details. If you're interested in submitting a patch, feel free to check our [development guide](docs/development.md) as well for ease into the project.
+__Contributing:__ Kedge is an evolving project and contributions are happily welcome. Feel free to open up an issue or even a PR. Read our [contributing guide](CONTRIBUTING.md) for more details. A thorough [development guide](http://kedgeproject.org/development/) is available if you're interested in contributing to Kedge.
 
 __Chat (Slack):__ We're fairly active on [Slack](https://kedgeproject.slack.com#kedge). You can invite yourself at [slack.kedgeproject.org](http://slack.kedgeproject.org).
 
-## License
+### License
 
 Unless otherwise stated (ex. `/vendor` files), all code is licensed under the [Apache 2.0 License](LICENSE). Portions of the project use libraries and code from other projects, the appropriate license can be found within the code (header of the file) or root directory within the `vendor` folder.
 
@@ -138,8 +72,5 @@ Unless otherwise stated (ex. `/vendor` files), all code is licensed under the [A
 [GoDoc Widget]: https://godoc.org/github.com/kedgeproject/kedge?status.svg
 [Slack]: http://slack.kedgeproject.org
 [Slack Widget]: https://s3.eu-central-1.amazonaws.com/ngtuna/join-us-on-slack.png
-[Bintray Latest Linux]:https://dl.bintray.com/kedgeproject/kedge/latest/kedge-linux-amd64
-[Bintray Latest macOS]:https://dl.bintray.com/kedgeproject/kedge/latest/kedge-darwin-amd64
-[Bintray Latest Windows]:https://dl.bintray.com/kedgeproject/kedge/latest/kedge-windows-amd64.exe
 [GoReportCard Widget]: https://goreportcard.com/badge/github.com/kedgeproject/kedge
 [GoReportCardResult]: https://goreportcard.com/report/github.com/kedgeproject/kedge

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,59 @@
+# Installation
+
+There are multiple ways of installing Kedge. Our prefered method is downloading the binary from the latest GitHub release.
+
+
+#### GitHub release
+
+Kedge is released via GitHub on a three-week cycle, you can see all current releases on the [GitHub release page](https://github.com/kedgeproject/kedge/releases).
+
+__Linux and macOS:__
+
+```sh
+# Linux
+curl -L https://github.com/kedgeproject/kedge/releases/download/v0.4.0/kedge-linux-amd64 -o kedge
+
+# macOS
+curl -L https://github.com/kedgeproject/kedge/releases/download/v0.4.0/kedge-darwin-amd64 -o kedge
+
+chmod +x kedge
+sudo mv ./kedge /usr/local/bin/kedge
+```
+
+__Windows:__
+
+Download from [GitHub](https://github.com/kedgeproject/kedge/releases/download/v0.4.0/kedge-windows-amd64.exe) and add the binary to your PATH.
+
+
+#### Installing the latest binary (master)
+
+You can download latest binary (built on each master PR merge) for [Linux (amd64)][Bintray Latest Linux], [macOS (darwin)][Bintray Latest macOS] or [Windows (amd64)][Bintray Latest Windows] from [Bintray](https://bintray.com):
+
+__Linux and macOS:__
+
+```sh
+# Linux 
+curl -L https://dl.bintray.com/kedgeproject/kedge/latest/kedge-linux-amd64 -o kedge
+
+# macOS
+curl -L https://dl.bintray.com/kedgeproject/kedge/latest/kedge-darwin-amd64 -o kedge
+
+chmod +x kedge
+sudo mv ./kedge /usr/local/bin/kedge
+```
+
+__Windows:__
+
+Download from [Bintray](https://dl.bintray.com/kedgeproject/kedge/latest/kedge-windows-amd64.exe) and add the binary to your PATH.
+
+#### Go get
+
+You can also download and build Kedge via Go:
+
+```sh
+go get github.com/kedgeproject/kedge
+```
+
+[Bintray Latest Linux]:https://dl.bintray.com/kedgeproject/kedge/latest/kedge-linux-amd64
+[Bintray Latest macOS]:https://dl.bintray.com/kedgeproject/kedge/latest/kedge-darwin-amd64
+[Bintray Latest Windows]:https://dl.bintray.com/kedgeproject/kedge/latest/kedge-windows-amd64.exe

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -58,4 +58,4 @@ No events.
 
 __Next steps__
 
-That's it! There's more examples in our [repository](https://github.com/kedgeproject/kedge/tree/master/examples). Check out the further documentation such as the [user guide](/docs/user_guide.md) or our [file reference](/docs/file_reference.md).
+That's it! There's more examples in our [repository](https://github.com/kedgeproject/kedge/tree/master/examples). Check out the further documentation such as the [user guide](/docs/user_guide.md) or our [file reference](/docs/file-reference.md).


### PR DESCRIPTION
Simplifies the README.md a bit, since we not only reference user / quick
astart guides elsewhere, but some of the information is redundant.
Removes "project status".

An installation doc is also added too.