### PR TITLE
Update examples to reflect shortcuts

### DIFF
--- a/examples/gitlab/gitlab.yml
+++ b/examples/gitlab/gitlab.yml
@@ -1,57 +1,18 @@
 name: gitlab
+
 labels:
     app: gitlab
+
 replicas: 1
+
 containers:
 - name: gitlab
   image: gitlab/gitlab-ce:9.4.1-ce.0
   imagePullPolicy: ""
-  env:
-  ## General GitLab Configs
-  ##
-  # This is a free-form env var that GitLab Omnibus uses to configure
-  # everything. We're passing this in from a configmap and pulling some
-  # of the values from the env vars defined below. This is done to
-  # avoid leaving secrets visible in kubectl.
-  - name: GITLAB_OMNIBUS_CONFIG
-    valueFrom:
-      configMapKeyRef:
-        name: gitlab
-        key: gitlab_omnibus_config
-  - name: GITLAB_ROOT_PASSWORD
-  - name: EXTERNAL_URL
-    value: "http://your-domain.com/"
-  ## DB configuration
-  ##
-  - name: DB_HOST
-    value: postgresql
-  - name: DB_USER
-    valueFrom:
-      secretKeyRef:
-        name: gitlab
-        key: db-user
-  - name: DB_PASSWORD
-    valueFrom:
-      secretKeyRef:
-        name: gitlab
-        key: db-password
-  - name: DB_DATABASE
-    value: "gitlab"
-  ## Redis configuration
-  ##
-  - name: REDIS_HOST
-    value: redis
-  - name: REDIS_PASSWORD
-    valueFrom:
-      secretKeyRef:
-        name: gitlab
-        key: redis-password
   livenessProbe:
     httpGet:
       path: /help
       port: 80
-    # This pod takes a very long time to start up. Be cautious when
-    # lowering this value to avoid Pod death during startup.
     initialDelaySeconds: 200
     timeoutSeconds: 1
     periodSeconds: 10
@@ -66,11 +27,6 @@ containers:
     periodSeconds: 10
     successThreshold: 1
     failureThreshold: 3
-  volumeMounts:
-  - name: gitlab-etc
-    mountPath: /etc/gitlab
-  - name: gitlab-data
-    mountPath: /gitlab-data
   resources:
     limits:
       cpu: 1
@@ -78,22 +34,56 @@ containers:
     requests:
       cpu: 500m
       memory: 1Gi
+
+  # Environment variables
+  env:
+  - name: GITLAB_OMNIBUS_CONFIG
+    valueFrom:
+      configMapKeyRef:
+        name: gitlab
+        key: gitlab_omnibus_config
+  - name: GITLAB_ROOT_PASSWORD
+  - name: EXTERNAL_URL
+    value: "http://your-domain.com/"
+  - name: DB_HOST
+    value: postgresql
+  - name: DB_USER
+    valueFrom:
+      secretKeyRef:
+        name: gitlab
+        key: db-user
+  - name: DB_PASSWORD
+    valueFrom:
+      secretKeyRef:
+        name: gitlab
+        key: db-password
+  - name: DB_DATABASE
+    value: "gitlab"
+  - name: REDIS_HOST
+    value: redis
+  - name: REDIS_PASSWORD
+    valueFrom:
+      secretKeyRef:
+        name: gitlab
+        key: redis-password
+
+  
+  volumeMounts:
+  - name: gitlab-etc
+    mountPath: /etc/gitlab
+  - name: gitlab-data
+    mountPath: /gitlab-data
+
           
 services:
 - name: gitlab
   labels:
     app: gitlab
   type: LoadBalancer
-  ports:
-  - name: ssh
-    port: 22
-    targetPort: 22
-  - name: http
-    port: 80
-    targetPort: 80
-  - name: https
-    port: 443
-    targetPort: 443
+  portMappings:
+    - 22:22
+    - 80:80
+    - 443:443
 
 volumeClaims:
 - name: gitlab-data
@@ -107,11 +97,9 @@ secrets:
    db-password: "Z2l0bGFi"
    redis-password: "Z2l0bGFi"
 
+# https://gitlab.com/gitlab-org/omnibus-gitlab/blob/master/files/gitlab-config-template/gitlab.rb.template
 configMaps:
 - data:
-  ## This is used by GitLab Omnibus as the primary means of configuration.
-  ## ref: https://gitlab.com/gitlab-org/omnibus-gitlab/blob/master/files/gitlab-config-template/gitlab.rb.template
-  ##
    gitlab_omnibus_config: |
     external_url ENV['EXTERNAL_URL'];
     root_pass = ENV['GITLAB_ROOT_PASSWORD'];

--- a/examples/gitlab/postgres.yml
+++ b/examples/gitlab/postgres.yml
@@ -1,27 +1,12 @@
 name: postgresql
+
 labels:
     app: postgresql
+
 containers:
 - name: postgresql
   image: "postgres:9.6"
   imagePullPolicy: ""
-  env:
-  - name: POSTGRES_USER
-    value: "gitlab"
-    # Required for pg_isready in the health probes.
-  - name: PGUSER
-    value: "gitlab"
-  - name: POSTGRES_DB
-    value: "gitlab"
-  - name: PGDATA
-    value: /var/lib/postgresql/data/pgdata
-  - name: POSTGRES_PASSWORD
-    valueFrom:
-      secretKeyRef:
-        name: postgresql
-        key: postgres-password
-  - name: POD_IP
-    valueFrom: { fieldRef: { fieldPath: status.podIP } }
   livenessProbe:
     exec:
       command:
@@ -45,6 +30,24 @@ containers:
       cpu: 100m
       memory: 256Mi
 
+  # Environment variables
+  env:
+  - name: POSTGRES_USER
+    value: "gitlab"
+  - name: PGUSER
+    value: "gitlab"
+  - name: POSTGRES_DB
+    value: "gitlab"
+  - name: PGDATA
+    value: /var/lib/postgresql/data/pgdata
+  - name: POSTGRES_PASSWORD
+    valueFrom:
+      secretKeyRef:
+        name: postgresql
+        key: postgres-password
+  - name: POD_IP
+    valueFrom: { fieldRef: { fieldPath: status.podIP } }
+
   volumeMounts:
   - name: data
     mountPath: /var/lib/postgresql/data/pgdata
@@ -54,10 +57,8 @@ services:
 - name: postgresql
   labels:
     app: postgresql
-  ports:
-  - name: postgresql
-    port: 5432
-    targetPort: 5432
+  portMappings:
+    - 5432:5432
 
 volumeClaims:
 - name: data

--- a/examples/gitlab/redis.yml
+++ b/examples/gitlab/redis.yml
@@ -1,16 +1,12 @@
 name: redis
+
 labels:
     app: redis
+
 containers:
 - name: redis
   image: "bitnami/redis:3.2.8-r1"
   imagePullPolicy: "IfNotPresent"
-  env:
-  - name: REDIS_PASSWORD
-    valueFrom:
-      secretKeyRef:
-        name: redis
-        key: redis-password
   livenessProbe:
     exec:
       command:
@@ -29,6 +25,15 @@ containers:
     requests:
       cpu: 100m
       memory: 1Gi
+
+  # Environment variables
+  env:
+  - name: REDIS_PASSWORD
+    valueFrom:
+      secretKeyRef:
+        name: redis
+        key: redis-password
+
   volumeMounts:
   - name: redis-data
     mountPath: /bitnami/redis
@@ -37,10 +42,8 @@ services:
 - name: redis
   labels:
     app: redis
-  ports:
-  - name: redis
-    port: 6379
-    targetPort: 6379
+  portMappings:
+    - 6379:6379
 
 volumeClaims:
 - name: redis-data

--- a/examples/guestbook-demo/backend.yaml
+++ b/examples/guestbook-demo/backend.yaml
@@ -1,7 +1,8 @@
 name: backend
+
 containers:
-  #- image: quay.io/tomkral/guestbook-demo-backend:v1
   - image: quay.io/tomkral/guestbook-demo-backend@sha256:abc9d419c2fc27511332471e7b82359f84ccec37577e1fcf05e7318145b3e125
+
     env:
       - name: MONGODB_PASSWORD
         valueFrom:
@@ -23,6 +24,7 @@ containers:
           configMapKeyRef:
             name: mongodb-user
             key: MONGODB_SERVER
+
 services:
-  - ports:
-    - port: 3000
+  - portMappings:
+    - 3000

--- a/examples/guestbook-demo/db.yaml
+++ b/examples/guestbook-demo/db.yaml
@@ -1,9 +1,8 @@
-# this should be idealy replaced by reference to Helm Chart
-
 name: mongodb
+
 containers:
-  #- image: bitnami/mongodb:3.4.7-r0
   - image: bitnami/mongodb@sha256:0665d6f4be13b965a8ff60a11b770e6434b627ffc12df640e3c0527af53d449b
+
     envFrom:
       - secretRef:
           name: mongodb-admin
@@ -11,15 +10,19 @@ containers:
           name: mongodb-user
       - configMapRef:
           name: mongodb-user
+
     volumeMounts:
      - name: mongodb-data
        mountPath: /bitnami
+
 services:
-  - ports:
-    - port: 27017
+  - portMappings:
+    - 27017
+
 volumeClaims:
   - name: mongodb-data
     size: 100Mi
+
 secrets:
   - name: mongodb-admin
     stringData:
@@ -27,6 +30,7 @@ secrets:
   - name: mongodb-user
     stringData:
       MONGODB_PASSWORD: pass
+
 configMaps:
   - name: mongodb-user
     data:

--- a/examples/guestbook-demo/frontend.yaml
+++ b/examples/guestbook-demo/frontend.yaml
@@ -1,8 +1,9 @@
 name: frontend
+
 containers:
-  #- image: quay.io/tomkral/guestbook-demo-frontend:v1
   - image: quay.io/tomkral/guestbook-demo-frontend@sha256:61154774892875ee2e6f4de87f08f5fcc7d736c1f9da02b9b33a583015206d1d
+
 services:
   - type: LoadBalancer
-    ports:
-    - port: 8080
+    portMappings:
+    - 8080

--- a/examples/wordpress/mariadb.yaml
+++ b/examples/wordpress/mariadb.yaml
@@ -2,6 +2,12 @@ name: database
 
 containers:
   - image: mariadb:10
+    health:
+      exec:
+        command:
+          - mysqladmin
+          - ping
+
     envFrom:
       - configMapRef:
          name: database
@@ -9,19 +15,15 @@ containers:
           name: database-root-password
       - secretRef:
           name: database-user-password
+
     volumeMounts:
       - name: database
         mountPath: /var/lib/mysql
-    health:
-      exec:
-        command:
-          - mysqladmin
-          - ping
 
 services:
   - name: database
-    ports:
-      - port: 3306
+    portMappings:
+      - 3306
 
 volumeClaims:
   - name: database
@@ -36,6 +38,7 @@ secrets:
   - name: database-root-password
     data:
       MYSQL_ROOT_PASSWORD: rootpass
+
   - name: database-user-password
     data:
       MYSQL_PASSWORD: userpass

--- a/examples/wordpress/wordpress.yaml
+++ b/examples/wordpress/wordpress.yaml
@@ -2,6 +2,13 @@ name: wordpress
 
 containers:
   - image: wordpress:4
+    health:
+      httpGet:
+        path: /
+        port: 80
+      initialDelaySeconds: 20
+      timeoutSeconds: 5
+
     env:
       - name: WORDPRESS_DB_NAME
         valueFrom:
@@ -21,15 +28,9 @@ containers:
       - name: WORDPRESS_DB_HOST
         value: database:3306
 
-    health:
-      httpGet:
-        path: /
-        port: 80
-      initialDelaySeconds: 20
-      timeoutSeconds: 5
 
 services:
   - name: wordpress
     type: LoadBalancer
-    ports:
-      - port: 80
+    portMappings:
+      - 80


### PR DESCRIPTION
Updates all the examples to reflect the "kedge" keys that enable
reducing the Kubernetes artifact file length. Such as portMappings and
health.