### PR TITLE
Update README with concise sentences, update quickstart guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,12 @@
 
 Kedge is a simple, easy and declarative way to define and deploy applications to Kubernetes by writing very concise application definitions.
 
-Key features and goals include:
+Why do people love Kedge?
 
-  - __An extension of Kubernetes:__ Use pre-existing definitions such as Pod or Container within your artifact file.
-  - __Declarative:__ Declarative definitions specifying developer's intent.
-  - __Simplicity:__ Using a simple and concise specification that is easy to understand and define.
-  - __Concise:__ Define just the necessary bits and Kedge will do the rest. Kedge will interprolate and pick the best defaults for your application to run on Kubernetes.
-  - __Multi-container environments:__ Define your containers, services and applications in one simple file, or split them into multiple files.
-  - __Familiar structure:__ Using a familiar YAML structure as Kubernetes, it's easy to pick-up and understand Kedge.
+  - __An extension of Kubernetes definitions:__ Use pre-existing definitions such as Pod or Container within your artifact file.
+  - __Shortcuts:__ Reduce your file-size and definitions by using intuitive Kedge shortcuts.
+  - __Concise:__ Define just the necessary bits, Kedge will interpolate and pick the best defaults for your application to run on Kubernetes.
+  - __Define all your containers in one place:__ Define your containers, services and applications in one simple file, or split them into multiple files.
 
 ----
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -8,12 +8,10 @@ Kedge is a simple, easy and declarative way to define and deploy applications to
 
 Why do people love Kedge?
 
-  - __Declarative:__ Declarative definitions specifying developer's intent.
-  - __Simplicity:__ Using a simple and concise specification that is easy to understand and define.
-  - __Concise:__ Define just the necessary bits and Kedge will do the rest. Kedge will interprolate and pick the best defaults for your application to run on Kubernetes.
-  - __Multi-container environments:__ Define your containers, services and applications in one simple file, or split them into multiple files.
-  - __Familiar structure:__ Using a familiar YAML structure as Kubernetes, it's easy to pick-up and understand Kedge.
-  - __Built on top of Kubernetes Pod definition:__ Leverages Kuberenetes Pod definition (PodSpec) and avoids leaky abstractions.
+  - __An extension of Kubernetes definitions:__ Use pre-existing definitions such as Pod or Container within your artifact file.
+  - __Shortcuts:__ Reduce your file-size and definitions by using intuitive Kedge shortcuts.
+  - __Concise:__ Define just the necessary bits, Kedge will interpolate and pick the best defaults for your application to run on Kubernetes.
+  - __Define all your containers in one place:__ Define your containers, services and applications in one simple file, or split them into multiple files.
 
 ### Avoid writing long artifact files, deploy an application straight to a Kubernetes cluster
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -28,6 +28,13 @@ deployment "httpd" created
 service "httpd" created
 ```
 
+__2.1. Alternatively, you can generate the raw Kubernetes artifact files and deploy it with `kubectl`.__
+
+```sh
+$ kedge generate -f httpd.yaml > output.yaml
+$ kubectl create -f output.yaml
+```
+
 __View the deployed service__
 
 Now that your service has been deployed, let's access it.


### PR DESCRIPTION
This updates the quickstart guide as well as the README.md and
introduction.md

I found that the points kind-of repeat themselves (See Concise and
Simplicity points).

Instead, alternative points such as "shortcuts" and reducing the overall
file-size of your file has been added.

Also, emphasizing that you can still use Kubernetes constructs within
your Kedge file.