### PR TITLE
update the fixContainers error message

### DIFF
--- a/pkg/spec/resources.go
+++ b/pkg/spec/resources.go
@@ -174,7 +174,7 @@ func fixContainers(containers []Container, appName string) ([]Container, error) 
 
 	for i, c := range containers {
 		if c.Name == "" {
-			return nil, fmt.Errorf("please specify name for app.ingresses[%d]", i)
+			return nil, fmt.Errorf("please specify name for app.containers[%d]", i)
 		}
 	}
 	return containers, nil


### PR DESCRIPTION
Error in the function that fixes containers wrongly returns error
saying ingress name should be given, so updating it rightly.