### PR TITLE
Kedge will read input from stdin

### DIFF
--- a/tests/cmd/cmd_test.go
+++ b/tests/cmd/cmd_test.go
@@ -112,5 +112,21 @@ func Test_builderror(t *testing.T) {
 	}
 	if strings.TrimSpace(string(output)) != imagename {
 		t.Errorf("Test Failed")
+
+	}
+}
+
+func Test_stdin(t *testing.T) {
+
+	kjson := `{"name": "httpd","containers": [{"image": "centos/httpd"}]}`
+	cmdStr := fmt.Sprintf("%s generate -f - <<EOF\n%s\nEOF\n", BinaryLocation, kjson)
+	subproc := exec.Command("/bin/sh", "-c", cmdStr)
+	output, err := subproc.Output()
+	if err != nil {
+		fmt.Println("Error executing command", err)
+	}
+	g, err := ioutil.ReadFile(Fixtures + "stdin/output.yml")
+	if !bytes.Equal(output, g) {
+		t.Errorf("Test Failed")
 	}
 }

--- a/tests/cmd/fixtures/stdin/output.yml
+++ b/tests/cmd/fixtures/stdin/output.yml
@@ -1,0 +1,22 @@
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    app: httpd
+  name: httpd
+spec:
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: httpd
+      name: httpd
+    spec:
+      containers:
+      - image: centos/httpd
+        name: httpd
+        resources: {}
+status: {}


### PR DESCRIPTION
Resolves #183

For example,

```
$ cat mariadb.yaml | kedge generate -f -
---
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  creationTimestamp: null
  labels:
    app: database
  name: database
...
...
```