### PR TITLE
This will add a new key appversion

### DIFF
--- a/pkg/spec/deployment.go
+++ b/pkg/spec/deployment.go
@@ -56,6 +56,10 @@ func (deployment *DeploymentSpecMod) Fix() error {
 
 	deployment.ControllerFields.ObjectMeta.Labels = addKeyValueToMap(appLabelKey, deployment.ControllerFields.Name, deployment.ControllerFields.ObjectMeta.Labels)
 
+	if deployment.ControllerFields.Appversion != "" {
+		deployment.ControllerFields.ObjectMeta.Annotations = addKeyValueToMap(appVersion, deployment.ControllerFields.Appversion, deployment.ControllerFields.ObjectMeta.Annotations)
+	}
+
 	return nil
 }
 
@@ -133,6 +137,8 @@ func (deployment *DeploymentSpecMod) createKubernetesController() (*ext_v1beta1.
 
 	// TODO: merge with already existing labels and avoid duplication
 	deploymentSpec.Template.ObjectMeta.Labels = deployment.Labels
+
+	deploymentSpec.Template.ObjectMeta.Annotations = deployment.Annotations
 
 	return &ext_v1beta1.Deployment{
 		ObjectMeta: deployment.ObjectMeta,

--- a/pkg/spec/deploymentconfig.go
+++ b/pkg/spec/deploymentconfig.go
@@ -65,6 +65,12 @@ func (deploymentConfig *DeploymentConfigSpecMod) fixDeploymentConfig() {
 		deploymentConfig.ControllerFields.Name,
 		deploymentConfig.ControllerFields.ObjectMeta.Labels)
 
+	if deploymentConfig.ControllerFields.Appversion != "" {
+		deploymentConfig.ControllerFields.ObjectMeta.Annotations = addKeyValueToMap(appVersion,
+			deploymentConfig.ControllerFields.Appversion,
+			deploymentConfig.ControllerFields.ObjectMeta.Annotations)
+	}
+
 	// If the replicas are not specified at all, we need to set the value as 1
 	if deploymentConfig.Replicas == nil {
 		deploymentConfig.Replicas = getInt32Addr(1)

--- a/pkg/spec/job.go
+++ b/pkg/spec/job.go
@@ -46,10 +46,15 @@ func (job *JobSpecMod) Fix() error {
 
 	job.ControllerFields.ObjectMeta.Labels = addKeyValueToMap(appLabelKey, job.ControllerFields.Name, job.ControllerFields.ObjectMeta.Labels)
 
+	if job.ControllerFields.Appversion != "" {
+		job.ControllerFields.ObjectMeta.Annotations = addKeyValueToMap(appVersion, job.ControllerFields.Appversion, job.ControllerFields.ObjectMeta.Annotations)
+	}
+
 	// if RestartPolicy is not set by user default it to 'OnFailure'
 	if job.RestartPolicy == "" {
 		job.RestartPolicy = api_v1.RestartPolicyOnFailure
 	}
+
 	return nil
 }
 
@@ -136,7 +141,6 @@ func (job *JobSpecMod) Validate() error {
 	if job.RestartPolicy == api_v1.RestartPolicyAlways {
 		return fmt.Errorf("the Job %q is invalid: restartPolicy: unsupported value: \"Always\": supported values: OnFailure, Never", job.Name)
 	}
-
 	return nil
 }
 

--- a/pkg/spec/types.go
+++ b/pkg/spec/types.go
@@ -163,6 +163,10 @@ type BuildConfigSpecMod struct {
 
 // ControllerFields are the common fields in every controller Kedge supports
 type ControllerFields struct {
+	// Field to specify the version of application
+	// +optional
+	Appversion string `json:"appversion,omitempty"`
+
 	Controller string `json:"controller,omitempty"`
 	// List of volume that should be mounted on the pod.
 	// ref: io.kedge.VolumeClaim

--- a/pkg/spec/util.go
+++ b/pkg/spec/util.go
@@ -22,16 +22,14 @@ import (
 	"encoding/json"
 
 	log "github.com/Sirupsen/logrus"
-	"github.com/pkg/errors"
-	"k8s.io/apimachinery/pkg/runtime"
-	//"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/kubernetes/pkg/api"
-	api_v1 "k8s.io/kubernetes/pkg/api/v1"
-	//kapi "k8s.io/kubernetes/pkg/api/v1"
 	build_v1 "github.com/openshift/origin/pkg/build/apis/build/v1"
 	os_deploy_v1 "github.com/openshift/origin/pkg/deploy/apis/apps/v1"
 	image_v1 "github.com/openshift/origin/pkg/image/apis/image/v1"
 	os_route_v1 "github.com/openshift/origin/pkg/route/apis/route/v1"
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/kubernetes/pkg/api"
+	api_v1 "k8s.io/kubernetes/pkg/api/v1"
 	batch_v1 "k8s.io/kubernetes/pkg/apis/batch/v1"
 )
 


### PR DESCRIPTION
This will add a new key `appversion` which will get reflected in the
metadata(as key-pair in annotation) of deployment, job and
deploymentConfig. It is optional and also empty value of `appversion`
will not be added to metadata #407