### PR TITLE
Allow the usage of a string or int as a value in portMappings

### DIFF
--- a/docs/examples/portMappings/mariadb.yaml
+++ b/docs/examples/portMappings/mariadb.yaml
@@ -12,5 +12,5 @@ containers:
     value: wordpress
 services:
 - portMappings:
-  - 3306:3306/TCP
+  - 3306
   type: NodePort

--- a/pkg/spec/deployment.go
+++ b/pkg/spec/deployment.go
@@ -33,7 +33,7 @@ import (
 func (deployment *DeploymentSpecMod) Unmarshal(data []byte) error {
 	err := yaml.Unmarshal(data, &deployment)
 	if err != nil {
-		return errors.Wrap(err, "could not unmarshal into internal struct")
+		return errors.Wrap(err, "Deployment could not unmarshal into internal struct")
 	}
 	log.Debugf("object unmarshalled: %#v\n", deployment)
 	return nil

--- a/pkg/spec/resources.go
+++ b/pkg/spec/resources.go
@@ -331,7 +331,7 @@ func (app *ControllerFields) createServices() ([]runtime.Object, error) {
 		}
 
 		for _, portMapping := range s.PortMappings {
-			servicePort, err := parsePortMapping(portMapping)
+			servicePort, err := parsePortMapping(portMapping.String())
 			if err != nil {
 				return nil, errors.Wrap(err, "unable to parse port mapping")
 			}

--- a/pkg/spec/types.go
+++ b/pkg/spec/types.go
@@ -22,6 +22,7 @@ import (
 	image_v1 "github.com/openshift/origin/pkg/image/apis/image/v1"
 	os_route_v1 "github.com/openshift/origin/pkg/route/apis/route/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	api_v1 "k8s.io/kubernetes/pkg/api/v1"
 	batch_v1 "k8s.io/kubernetes/pkg/apis/batch/v1"
 	ext_v1beta1 "k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
@@ -63,7 +64,7 @@ type ServiceSpecMod struct {
 	// The list of portMappings, where each portMapping allows specifying port,
 	// targetPort and protocol in the format '<port>:<targetPort>/<protocol>'
 	// +optional
-	PortMappings []string `json:"portMappings,omitempty"`
+	PortMappings []intstr.IntOrString `json:"portMappings,omitempty"`
 	// k8s: io.k8s.kubernetes.pkg.apis.meta.v1.ObjectMeta
 	meta_v1.ObjectMeta `json:",inline"`
 }

--- a/tests/cmd/portmappings/port-mixed.yaml
+++ b/tests/cmd/portmappings/port-mixed.yaml
@@ -1,0 +1,11 @@
+name: database
+
+containers:
+  - image: mariadb:10
+
+services:
+  - name: database
+    portMappings:
+      - 80
+      - "3306"
+      - "3307"

--- a/tests/cmd/portmappings/port-port.yaml
+++ b/tests/cmd/portmappings/port-port.yaml
@@ -1,0 +1,9 @@
+name: database
+
+containers:
+  - image: mariadb:10
+
+services:
+  - name: database
+    portMappings:
+      - 3306:3306

--- a/tests/cmd/portmappings/port-string.yaml
+++ b/tests/cmd/portmappings/port-string.yaml
@@ -1,0 +1,9 @@
+name: database
+
+containers:
+  - image: mariadb:10
+
+services:
+  - name: database
+    portMappings:
+      - "3306"

--- a/tests/cmd/portmappings/port.yaml
+++ b/tests/cmd/portmappings/port.yaml
@@ -1,0 +1,9 @@
+name: database
+
+containers:
+  - image: mariadb:10
+
+services:
+  - name: database
+    portMappings:
+      - 3306


### PR DESCRIPTION
This allows the use of specifying either (for example) "80" or 80 within
portMappings of the Kedge file.