### PR TITLE
docs(routes): indent the routes example in README

### DIFF
--- a/docs/examples/routes/README.md
+++ b/docs/examples/routes/README.md
@@ -5,21 +5,34 @@ to define OpenShift routes.
 
 An OpenShift route is a way to expose a service by giving it an
 externally-reachable hostname.
-More info at https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/routes.html
+More info about routes can be found [here](https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/routes.html)
 
 Much like other resource definitions in Kedge, routes have been implemented
 by merging `RouteSpec` and `ObjectMeta`, which would mean that you can
 define fields like `name` and the rest of the RouteSpec at the same level.
 
-An example would be -
+A snippet from [httpd.yml](httpd.yml):
+
 ```yaml
-name: webroute
-host: httpd-web.192.168.42.69.nip.io
-to:
-  kind: Service
-  name: httpd
-  weight: 100
-wildcardPolicy: None
+...
+routes:
+- to:
+    kind: Service
+    name: httpd
+```
+
+A more detailed example might look like this:
+
+```yaml
+...
+routes:
+- name: webroute
+  host: httpd-web.192.168.42.69.nip.io
+  to:
+    kind: Service
+    name: httpd
+    weight: 100
+  wildcardPolicy: None
 ```
 
 ## Ref


### PR DESCRIPTION
Right now the way routes example is explained in it's README, it is
not very helpful and can confuse user, so placing it in right
indentation.

Fixes https://github.com/kedgeproject/kedge/issues/402