### PR TITLE
Adding OpenShift tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,6 +93,11 @@ endif
 test-cmd: bin
 	go test -v github.com/kedgeproject/kedge/tests/cmd
 
+# Run OpenShift tests
+.PHONY: test-e2e-os
+test-e2e-os:
+	TEST=os make test-e2e 
+
 # Run all tests
 .PHONY: test
 test: test-dep validate test-unit test-cmd test-unit-cover
@@ -132,4 +137,3 @@ vendor-update:
 .PHONY: test-jsonschema-generation
 test-jsonschema-generation:
 	docker run -v `pwd`/pkg/spec/types.go:/data/types.go:ro,Z surajd/kedgeschema
-

--- a/docs/examples/s2i/app.py
+++ b/docs/examples/s2i/app.py
@@ -1,0 +1,18 @@
+from flask import Flask
+from redis import Redis
+import os
+
+app = Flask(__name__)
+redis = Redis(host=os.environ.get('REDIS_HOST', 'redis'), port=6379)
+
+@app.route('/')
+def hello():
+    visits = redis.incr('hits')
+
+    html = "<h3>Hello Kubernauts</h3> <br/>" \
+           "<h2>Number of Hits:</2> {hits}<br/>"
+
+    return html.format(hits=visits)
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=5000, debug=True)

--- a/docs/examples/s2i/configs/application.yaml
+++ b/docs/examples/s2i/configs/application.yaml
@@ -1,0 +1,27 @@
+name: ticker
+controller: deploymentconfig
+
+containers:
+- image: ""
+  env:
+  - name: REDIS_HOST
+    value: redis
+
+triggers:
+- imageChangeParams:
+    automatic: true
+    containerNames:
+    - ticker
+    from:
+      kind: ImageStreamTag
+      name: ticker:latest
+  type: ImageChange
+
+services:
+- portMappings:
+  - 15000:5000
+
+routes:
+- to:
+    kind: Service
+    name: ticker

--- a/docs/examples/s2i/configs/redis.yaml
+++ b/docs/examples/s2i/configs/redis.yaml
@@ -1,0 +1,7 @@
+name: redis
+controller: deploymentconfig
+containers:
+- image: redis
+services:
+- portMappings:
+  - "6379"

--- a/scripts/run_e2e.sh
+++ b/scripts/run_e2e.sh
@@ -35,6 +35,12 @@ if [ -n "$VERBOSE" ]; then
     run_command+=" -v"
 fi
 
+if [ -n "$TEST" ]; then
+    run_command+=" -run=$TEST"
+else
+    run_command+=" -run=k8s"
+fi
+
 run_command+=" github.com/kedgeproject/kedge/tests/e2e"
 
 # Run e2e tests
@@ -47,7 +53,11 @@ echo "| Tests will be ran against a k8s    |"
 echo "| cluster in separate namespaces     |"
 echo "|                                    |"
 echo "| Use command:                       |"
-echo -e "| \e[1;34mVERBOSE=yes make test-e2e\e[0m          |"
+if [ "$TEST" == "os" ]; then
+    echo -e "| \e[1;34mVERBOSE=yes make test-e2e-os\e[0m       |"
+else
+    echo -e "| \e[1;34mVERBOSE=yes make test-e2e\e[0m          |"
+fi
 echo "| for verbosity.                     |"
 echo "======================================"
 echo ""

--- a/tests/e2e/e2e.go
+++ b/tests/e2e/e2e.go
@@ -32,7 +32,8 @@ var BinaryLocation = ProjectPath + "kedge"
 var BinaryCommand = []string{"create", "-n"}
 
 const (
-	jobTimeout = 10 * time.Minute
+	jobTimeout   = 10 * time.Minute
+	waitInterval = 5
 )
 
 func homeDir() string {
@@ -147,8 +148,7 @@ func PodsStarted(t *testing.T, clientset *kubernetes.Clientset, namespace string
 
 // Wait for the jobs to complete
 func waitForJobComplete(clientset *kubernetes.Clientset, namespace string, jobName string) error {
-	// Interval of 5
-	return wait.Poll(5, jobTimeout, func() (bool, error) {
+	return wait.Poll(waitInterval, jobTimeout, func() (bool, error) {
 		jobStatus, err := clientset.Batch().Jobs(namespace).Get(jobName, metav1.GetOptions{})
 		if err != nil {
 			return false, errors.Wrap(err, "error getting jobs")
@@ -255,187 +255,5 @@ type testData struct {
 	PodStarted       []string
 	NodePortServices []ServicePort
 	Type             string
-}
-
-// The "bread and butter" of the test-suite. We will iterate through
-// each test that is required and make sure that not only are the pods started
-// but that each test is pingable / is accessable.
-func Test_Integration(t *testing.T) {
-	clientset, err := createClient()
-	if err != nil {
-		t.Fatalf("error getting kube client: %v", err)
-	}
-
-	tests := []testData{
-		{
-			TestName:  "Testing configmap",
-			Namespace: "configmap",
-			InputFiles: []string{
-				ProjectPath + TestPath + "configmap/guestbook.yaml",
-				ProjectPath + TestPath + "configmap/redis-master.yaml",
-				ProjectPath + TestPath + "configmap/redis-slave.yaml",
-			},
-			PodStarted: []string{"guestbook", "redis-master", "redis-slave"},
-			NodePortServices: []ServicePort{
-				{Name: "guestbook", Port: 3000},
-			},
-		},
-		{
-			TestName:  "Testing custom-vol",
-			Namespace: "custom-vol",
-			InputFiles: []string{
-				ProjectPath + TestPath + "custom-vol/guestbook.yaml",
-				ProjectPath + TestPath + "custom-vol/redis-master.yaml",
-				ProjectPath + TestPath + "custom-vol/redis-slave.yaml",
-			},
-			PodStarted: []string{"guestbook", "redis-master", "redis-slave"},
-			NodePortServices: []ServicePort{
-				{Name: "guestbook", Port: 3000},
-			},
-		},
-		{
-			TestName:  "Testing health",
-			Namespace: "health",
-			InputFiles: []string{
-				ProjectPath + TestPath + "health/guestbook.yaml",
-				ProjectPath + TestPath + "health/redis-master.yaml",
-				ProjectPath + TestPath + "health/redis-slave.yaml",
-			},
-			PodStarted: []string{"guestbook", "redis-master", "redis-slave"},
-			NodePortServices: []ServicePort{
-				{Name: "guestbook", Port: 3000},
-			},
-		},
-		{
-			TestName:  "Testing health-check",
-			Namespace: "health-check",
-			InputFiles: []string{
-				ProjectPath + TestPath + "health-check/guestbook.yaml",
-				ProjectPath + TestPath + "health-check/redis-master.yaml",
-				ProjectPath + TestPath + "health-check/redis-slave.yaml",
-			},
-			PodStarted: []string{"guestbook", "redis-master", "redis-slave"},
-			NodePortServices: []ServicePort{
-				{Name: "guestbook", Port: 3000},
-			},
-		},
-		{
-			TestName:  "Testing secret",
-			Namespace: "secret",
-			InputFiles: []string{
-				ProjectPath + TestPath + "secret/guestbook.yaml",
-				ProjectPath + TestPath + "secret/redis-master.yaml",
-				ProjectPath + TestPath + "secret/redis-slave.yaml",
-			},
-			PodStarted: []string{"guestbook", "redis-master", "redis-slave"},
-			NodePortServices: []ServicePort{
-				{Name: "guestbook", Port: 3000},
-			},
-		},
-		{
-			TestName:  "Test port-mappings",
-			Namespace: "port-mappings",
-			InputFiles: []string{
-				ProjectPath + TestPath + "port-mappings/guestbook.yaml",
-				ProjectPath + TestPath + "port-mappings/redis-master.yaml",
-				ProjectPath + TestPath + "port-mappings/redis-slave.yaml",
-			},
-			PodStarted: []string{"guestbook", "redis-master", "redis-slave"},
-			NodePortServices: []ServicePort{
-				{Name: "guestbook", Port: 3000},
-			},
-		},
-		// Special non-guestbook-go-redis tests
-		{
-			TestName:  "Testing single-file",
-			Namespace: "single-file",
-			InputFiles: []string{
-				ProjectPath + TestPath + "single-file/guestbook.yaml",
-			},
-			PodStarted: []string{"guestbook", "redis-master", "redis-slave"},
-			NodePortServices: []ServicePort{
-				{Name: "guestbook", Port: 3000},
-			},
-		},
-		{
-			TestName:  "Test jobs",
-			Namespace: "jobs",
-			InputFiles: []string{
-				ProjectPath + TestPath + "jobs/job.yaml",
-			},
-			PodStarted: []string{"pival"},
-			Type:       "job",
-		},
-		{
-			TestName:  "Testing include-resources",
-			Namespace: "include-resources",
-			InputFiles: []string{
-				ProjectPath + TestPath + "include-resources/web.yaml",
-			},
-			PodStarted: []string{"web"},
-			NodePortServices: []ServicePort{
-				{Name: "web", Port: 80},
-			},
-		},
-	}
-
-	_, err = clientset.CoreV1().Pods("").List(metav1.ListOptions{})
-	if err != nil {
-		t.Fatalf("Kubernetes cluster is not running or not accessible: %v", err)
-	}
-
-	for _, test := range tests {
-		test := test // capture range variable
-		t.Run(test.TestName, func(t *testing.T) {
-			t.Parallel()
-			// create a namespace
-			_, err := createNS(clientset, test.Namespace)
-			if err != nil {
-				t.Fatalf("error creating namespace: %v", err)
-			}
-			t.Logf("namespace %q created", test.Namespace)
-			defer deleteNamespace(t, clientset, test.Namespace)
-
-			// run kedge
-			convertedOutput, err := RunBinary(test.InputFiles, test.Namespace)
-			if err != nil {
-				t.Fatalf("error running kedge: %v", err)
-			}
-			t.Log(string(convertedOutput))
-
-			// see if the pods are running
-			if err := PodsStarted(t, clientset, test.Namespace, test.PodStarted); err != nil {
-				t.Fatalf("error finding running pods: %v", err)
-			}
-
-			if test.Type == "job" {
-				listJobs, err := clientset.Batch().Jobs(test.Namespace).List(metav1.ListOptions{})
-				if err != nil {
-					t.Fatalf("error getting the job list: %v", err)
-				}
-
-				for _, job := range listJobs.Items {
-					err := waitForJobComplete(clientset, test.Namespace, job.Name)
-					if err != nil {
-						t.Fatalf("Job failed: %v", err)
-					}
-
-					t.Logf("Successfully completed the job: %s", job.Name)
-				}
-			} else {
-
-				// get endpoints for all services
-				endPoints, err := getEndPoints(t, clientset, test.Namespace, test.NodePortServices)
-				if err != nil {
-					t.Fatalf("error getting nodes: %v", err)
-				}
-
-				if err := pingEndPoints(t, endPoints); err != nil {
-					t.Fatalf("error pinging endpoint: %v", err)
-				}
-
-				t.Logf("Successfully pinged all endpoints!")
-			}
-		})
-	}
+	BaseImage        string
 }

--- a/tests/e2e/e2e_k8s_test.go
+++ b/tests/e2e/e2e_k8s_test.go
@@ -1,0 +1,189 @@
+package e2e
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"testing"
+)
+
+// The "bread and butter" of the test-suite. We will iterate through
+// each test that is required and make sure that not only are the pods started
+// but that each test is pingable / is accessable.
+func Test_k8s_Integration(t *testing.T) {
+	clientset, err := createClient()
+	if err != nil {
+		t.Fatalf("error getting kube client: %v", err)
+	}
+
+	tests := []testData{
+		{
+			TestName:  "Testing configmap",
+			Namespace: "configmap",
+			InputFiles: []string{
+				ProjectPath + TestPath + "configmap/guestbook.yaml",
+				ProjectPath + TestPath + "configmap/redis-master.yaml",
+				ProjectPath + TestPath + "configmap/redis-slave.yaml",
+			},
+			PodStarted: []string{"guestbook", "redis-master", "redis-slave"},
+			NodePortServices: []ServicePort{
+				{Name: "guestbook", Port: 3000},
+			},
+		},
+		{
+			TestName:  "Testing custom-vol",
+			Namespace: "custom-vol",
+			InputFiles: []string{
+				ProjectPath + TestPath + "custom-vol/guestbook.yaml",
+				ProjectPath + TestPath + "custom-vol/redis-master.yaml",
+				ProjectPath + TestPath + "custom-vol/redis-slave.yaml",
+			},
+			PodStarted: []string{"guestbook", "redis-master", "redis-slave"},
+			NodePortServices: []ServicePort{
+				{Name: "guestbook", Port: 3000},
+			},
+		},
+		{
+			TestName:  "Testing health",
+			Namespace: "health",
+			InputFiles: []string{
+				ProjectPath + TestPath + "health/guestbook.yaml",
+				ProjectPath + TestPath + "health/redis-master.yaml",
+				ProjectPath + TestPath + "health/redis-slave.yaml",
+			},
+			PodStarted: []string{"guestbook", "redis-master", "redis-slave"},
+			NodePortServices: []ServicePort{
+				{Name: "guestbook", Port: 3000},
+			},
+		},
+		{
+			TestName:  "Testing health-check",
+			Namespace: "health-check",
+			InputFiles: []string{
+				ProjectPath + TestPath + "health-check/guestbook.yaml",
+				ProjectPath + TestPath + "health-check/redis-master.yaml",
+				ProjectPath + TestPath + "health-check/redis-slave.yaml",
+			},
+			PodStarted: []string{"guestbook", "redis-master", "redis-slave"},
+			NodePortServices: []ServicePort{
+				{Name: "guestbook", Port: 3000},
+			},
+		},
+		{
+			TestName:  "Testing secret",
+			Namespace: "secret",
+			InputFiles: []string{
+				ProjectPath + TestPath + "secret/guestbook.yaml",
+				ProjectPath + TestPath + "secret/redis-master.yaml",
+				ProjectPath + TestPath + "secret/redis-slave.yaml",
+			},
+			PodStarted: []string{"guestbook", "redis-master", "redis-slave"},
+			NodePortServices: []ServicePort{
+				{Name: "guestbook", Port: 3000},
+			},
+		},
+		{
+			TestName:  "Test port-mappings",
+			Namespace: "port-mappings",
+			InputFiles: []string{
+				ProjectPath + TestPath + "port-mappings/guestbook.yaml",
+				ProjectPath + TestPath + "port-mappings/redis-master.yaml",
+				ProjectPath + TestPath + "port-mappings/redis-slave.yaml",
+			},
+			PodStarted: []string{"guestbook", "redis-master", "redis-slave"},
+			NodePortServices: []ServicePort{
+				{Name: "guestbook", Port: 3000},
+			},
+		},
+		// Special non-guestbook-go-redis tests
+		{
+			TestName:  "Testing single-file",
+			Namespace: "single-file",
+			InputFiles: []string{
+				ProjectPath + TestPath + "single-file/guestbook.yaml",
+			},
+			PodStarted: []string{"guestbook", "redis-master", "redis-slave"},
+			NodePortServices: []ServicePort{
+				{Name: "guestbook", Port: 3000},
+			},
+		},
+		{
+			TestName:  "Test jobs",
+			Namespace: "jobs",
+			InputFiles: []string{
+				ProjectPath + TestPath + "jobs/job.yaml",
+			},
+			PodStarted: []string{"pival"},
+			Type:       "job",
+		},
+		{
+			TestName:  "Testing include-resources",
+			Namespace: "include-resources",
+			InputFiles: []string{
+				ProjectPath + TestPath + "include-resources/web.yaml",
+			},
+			PodStarted: []string{"web"},
+			NodePortServices: []ServicePort{
+				{Name: "web", Port: 80},
+			},
+		},
+	}
+
+	_, err = clientset.CoreV1().Pods("").List(metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("Kubernetes cluster is not running or not accessible: %v", err)
+	}
+
+	for _, test := range tests {
+		test := test // capture range variable
+		t.Run(test.TestName, func(t *testing.T) {
+			t.Parallel()
+			// create a namespace
+			_, err := createNS(clientset, test.Namespace)
+			if err != nil {
+				t.Fatalf("error creating namespace: %v", err)
+			}
+			t.Logf("namespace %q created", test.Namespace)
+			defer deleteNamespace(t, clientset, test.Namespace)
+
+			// run kedge
+			convertedOutput, err := RunBinary(test.InputFiles, test.Namespace)
+			if err != nil {
+				t.Fatalf("error running kedge: %v", err)
+			}
+			t.Log(string(convertedOutput))
+
+			// see if the pods are running
+			if err := PodsStarted(t, clientset, test.Namespace, test.PodStarted); err != nil {
+				t.Fatalf("error finding running pods: %v", err)
+			}
+
+			if test.Type == "job" {
+				listJobs, err := clientset.Batch().Jobs(test.Namespace).List(metav1.ListOptions{})
+				if err != nil {
+					t.Fatalf("error getting the job list: %v", err)
+				}
+
+				for _, job := range listJobs.Items {
+					err := waitForJobComplete(clientset, test.Namespace, job.Name)
+					if err != nil {
+						t.Fatalf("Job failed: %v", err)
+					}
+
+					t.Logf("Successfully completed the job: %s", job.Name)
+				}
+			} else {
+
+				// get endpoints for all services
+				endPoints, err := getEndPoints(t, clientset, test.Namespace, test.NodePortServices)
+				if err != nil {
+					t.Fatalf("error getting nodes: %v", err)
+				}
+
+				if err := pingEndPoints(t, endPoints); err != nil {
+					t.Fatalf("error pinging endpoint: %v", err)
+				}
+
+				t.Logf("Successfully pinged all endpoints!")
+			}
+		})
+	}
+}

--- a/tests/e2e/e2e_os_test.go
+++ b/tests/e2e/e2e_os_test.go
@@ -1,0 +1,149 @@
+package e2e
+
+import (
+	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func waitForBuildComplete(namespace string, buildName string) error {
+	return wait.Poll(waitInterval, jobTimeout, func() (bool, error) {
+		var buildOut bool
+		buildStatus, err := runCmd("oc get build --namespace=" + namespace +
+			" --template='{{ range .items }}{{ if (eq .metadata.name \"" +
+			buildName + "\") }}{{ eq .status.phase \"Complete\" }}{{end}}{{end}}'")
+		if err != nil {
+			return false, errors.Wrap(err, "error getting build status")
+		}
+
+		buildOut, _ = strconv.ParseBool(string(buildStatus))
+		return buildOut, nil
+	})
+}
+
+func runKedgeS2i(imageName string, baseImage string) error {
+	s2iCmd := BinaryLocation + " build --s2i --image " + imageName + " -b " + baseImage
+	_, err := runCmd(s2iCmd)
+	if err != nil {
+		return errors.Wrap(err, "error build s2i image")
+	}
+	return nil
+}
+
+// TODO: Use OpenShift client-go API instead of go-template
+func Test_os_Integration(t *testing.T) {
+	clientset, err := createClient()
+	if err != nil {
+		t.Fatalf("error getting kube client: %v", err)
+	}
+
+	tests := []testData{
+		{
+			TestName:  "Testing routes",
+			Namespace: "testroutes",
+			InputFiles: []string{
+				ProjectPath + TestPath + "routes/httpd.yml",
+			},
+			PodStarted: []string{"httpd"},
+			NodePortServices: []ServicePort{
+				{Name: "httpd", Port: 8080},
+			},
+		},
+
+		{
+			TestName:  "Testing buildconfig",
+			Namespace: "buildconfig",
+			InputFiles: []string{
+				ProjectPath + TestPath + "buildConfigs/ruby-hello-world.yml",
+			},
+			PodStarted: []string{"ruby"},
+			Type:       "buildconfig",
+		},
+
+		{
+			TestName:  "Testing s2i image",
+			Namespace: "s2i",
+			InputFiles: []string{
+				ProjectPath + TestPath + "s2i/configs/",
+			},
+			PodStarted: []string{"redis"},
+			Type:       "s2i",
+			BaseImage:  "centos/python-35-centos7:3.5",
+		},
+	}
+
+	_, err = clientset.CoreV1().Pods("").List(metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("OC cluster is not running or not accessible: %v", err)
+	}
+
+	for _, test := range tests {
+		test := test // capture range variable
+		t.Run(test.TestName, func(t *testing.T) {
+			t.Parallel()
+			// create an OpenShift project
+			_, err := runCmd("oc new-project " + test.Namespace)
+			if err != nil {
+				t.Fatalf("error creating project: %v", err)
+			}
+			t.Logf("project %q created", test.Namespace)
+
+			defer deleteNamespace(t, clientset, test.Namespace)
+
+			if test.Type == "s2i" {
+				err := runKedgeS2i(test.Namespace, test.BaseImage)
+				if err != nil {
+					t.Fatalf("error running kedge s2i: %v", err)
+				}
+			}
+
+			// run kedge
+			convertedOutput, err := RunBinary(test.InputFiles, test.Namespace)
+			if err != nil {
+				t.Fatalf("error running kedge: %v", err)
+			}
+			t.Log(string(convertedOutput))
+
+			// see if the pods are running
+			if err := PodsStarted(t, clientset, test.Namespace, test.PodStarted); err != nil {
+				t.Fatalf("error finding running pods: %v", err)
+			}
+
+			if (test.Type == "buildconfig") || (test.Type == "s2i") {
+				listBuilds, err := runCmd("oc get build --namespace=" + test.Namespace +
+					" --template='{{range .items}}{{ .metadata.name }}:{{end}}' | tr \":\" \"\n\"")
+				if err != nil {
+					t.Fatalf("error getting the Build list: %v", err)
+				}
+
+				eachBuild := strings.Split(string(listBuilds), "\n")
+				for _, build := range eachBuild {
+					if len(build) > 0 {
+						err := waitForBuildComplete(test.Namespace, build)
+						if err != nil {
+							t.Fatalf("Build failed: %v", err)
+						}
+
+						t.Logf("Successfully completed the build: %s", build)
+					}
+				}
+			}
+
+			// get endpoints for all services
+			endPoints, err := getEndPoints(t, clientset, test.Namespace, test.NodePortServices)
+			if err != nil {
+				t.Fatalf("error getting nodes: %v", err)
+			}
+
+			if err := pingEndPoints(t, endPoints); err != nil {
+				t.Fatalf("error pinging endpoint: %v", err)
+			}
+
+			t.Logf("Successfully pinged all endpoints!")
+
+		})
+	}
+}


### PR DESCRIPTION
For OpenShift, we reuse the functions which we use for  k8s tests. So for this purpose, this commit puts those functions into a separate file: tests/e2e/e2e.go
    
The k8s tests are put under: tests/e2e/e2e_k8s_test.go
    
The OpenShift tests are in tests/e2e/e2e_os_test.go
    
The e2e script has been modified to run only k8s tests  by default (by using the `go test -run k8s`)
    
To run OpenShift tests: `go test -run os`