### PR TITLE
add BuildConfig support

### DIFF
--- a/pkg/cmd/commands.go
+++ b/pkg/cmd/commands.go
@@ -64,7 +64,7 @@ func CreateArtifacts(paths []string, generate bool, args ...string) error {
 		for _, runtimeObject := range ros {
 			switch runtimeObject.GetObjectKind().GroupVersionKind().Kind {
 			// If there is at least one OpenShift resource use oc
-			case "DeploymentConfig", "Route", "ImageStream":
+			case "DeploymentConfig", "Route", "ImageStream", "BuildConfig":
 				useOC = true
 				break
 			}

--- a/pkg/spec/resources.go
+++ b/pkg/spec/resources.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	log "github.com/Sirupsen/logrus"
+	build_v1 "github.com/openshift/origin/pkg/build/apis/build/v1"
 	image_v1 "github.com/openshift/origin/pkg/image/apis/image/v1"
 	os_route_v1 "github.com/openshift/origin/pkg/route/apis/route/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -146,6 +147,26 @@ func fixImageStreams(imageStreams []ImageStreamSpecMod, appName string) ([]Image
 	return imageStreams, nil
 }
 
+func fixBuildConfigs(buildConfigs []BuildConfigSpecMod, appName string) ([]BuildConfigSpecMod, error) {
+
+	// auto populate name only if one buildConfig is specified without any name
+	if len(buildConfigs) == 1 && buildConfigs[0].Name == "" {
+		buildConfigs[0].ObjectMeta.Name = appName
+	}
+
+	for i, bc := range buildConfigs {
+		if bc.Name == "" {
+			return nil, fmt.Errorf("please specify name for app.buildConfigs[%d]", i)
+		}
+
+		bc.ObjectMeta.Labels = addKeyValueToMap(appLabelKey, appName, bc.ObjectMeta.Labels)
+
+		// this should be the last statement in this for loop
+		buildConfigs[i] = bc
+	}
+	return buildConfigs, nil
+}
+
 func fixIngresses(ingresses []IngressSpecMod, appName string) ([]IngressSpecMod, error) {
 
 	// auto populate name only if one ingress is specified without any name
@@ -242,6 +263,12 @@ func (cf *ControllerFields) fixControllerFields() error {
 	cf.ImageStreams, err = fixImageStreams(cf.ImageStreams, cf.Name)
 	if err != nil {
 		return errors.Wrap(err, "unable to fix imageStreams")
+	}
+
+	// fix buildConfigs
+	cf.BuildConfigs, err = fixBuildConfigs(cf.BuildConfigs, cf.Name)
+	if err != nil {
+		return errors.Wrap(err, "unable to fix buildConfigs")
 	}
 
 	// fix ingresses
@@ -440,6 +467,19 @@ func (app *ControllerFields) createImageStreams() ([]runtime.Object, error) {
 	return imageStreams, nil
 }
 
+func (app *ControllerFields) createBuildConfigs() ([]runtime.Object, error) {
+	var buildConfigs []runtime.Object
+
+	for _, b := range app.BuildConfigs {
+		buildConfig := &build_v1.BuildConfig{
+			ObjectMeta: b.ObjectMeta,
+			Spec:       b.BuildConfigSpec,
+		}
+		buildConfigs = append(buildConfigs, buildConfig)
+	}
+	return buildConfigs, nil
+}
+
 // CreateK8sObjects, if given object DeploymentSpecMod, this function reads
 // them and returns kubernetes objects as list of runtime.Object
 // If the deployment is using field 'includeResources' then it will
@@ -474,6 +514,11 @@ func (app *ControllerFields) CreateK8sObjects() ([]runtime.Object, []string, err
 	iss, err := app.createImageStreams()
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "unable to create OpenShift ImageStreams")
+	}
+
+	bcs, err := app.createBuildConfigs()
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "Unable to create OpenShift BuildConfigs")
 	}
 
 	app.PodSpec.Containers, err = populateContainers(app.Containers, app.ConfigMaps, app.Secrets)
@@ -533,6 +578,9 @@ func (app *ControllerFields) CreateK8sObjects() ([]runtime.Object, []string, err
 
 	objects = append(objects, iss...)
 	log.Debugf("app: %s, imageStreams: %s\n", app.Name, spew.Sprint(iss))
+
+	objects = append(objects, bcs...)
+	log.Debugf("app: %s, buildConfig: %s\n", app.Name, spew.Sprint(bcs))
 
 	objects = append(objects, configMap...)
 	log.Debugf("app: %s, configMap: %s\n", app.Name, spew.Sprint(configMap))

--- a/pkg/spec/types.go
+++ b/pkg/spec/types.go
@@ -17,6 +17,7 @@ limitations under the License.
 package spec
 
 import (
+	build_v1 "github.com/openshift/origin/pkg/build/apis/build/v1"
 	os_deploy_v1 "github.com/openshift/origin/pkg/deploy/apis/apps/v1"
 	image_v1 "github.com/openshift/origin/pkg/image/apis/image/v1"
 	os_route_v1 "github.com/openshift/origin/pkg/route/apis/route/v1"
@@ -151,6 +152,14 @@ type ImageStreamSpecMod struct {
 	meta_v1.ObjectMeta `json:",inline"`
 }
 
+// BuildConfigSpecMod defines OpenShift BuildConfig object
+// kedgeSpec: io.kedge.BuildConfigSpec
+type BuildConfigSpecMod struct {
+	build_v1.BuildConfigSpec `json:",inline"`
+	// k8s: io.k8s.kubernetes.pkg.apis.meta.v1.ObjectMeta
+	meta_v1.ObjectMeta `json:",inline"`
+}
+
 // ControllerFields are the common fields in every controller Kedge supports
 type ControllerFields struct {
 	Controller string `json:"controller,omitempty"`
@@ -182,6 +191,10 @@ type ControllerFields struct {
 	// ref: io.kedge.ImageStreamSpec
 	// +optional
 	ImageStreams []ImageStreamSpecMod `json:"imageStreams,omitempty"`
+	// List of OpenShift BuildConfigs
+	// ref: io.kedge.BuildConfigSpec
+	// +optional
+	BuildConfigs []BuildConfigSpecMod `json:"buildConfigs,omitempty"`
 	// List of Kubernetes resource files, that can be directly given to Kubernetes
 	// +optional
 	IncludeResources []string `json:"includeResources,omitempty"`

--- a/pkg/spec/util.go
+++ b/pkg/spec/util.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	api_v1 "k8s.io/kubernetes/pkg/api/v1"
 	//kapi "k8s.io/kubernetes/pkg/api/v1"
+	build_v1 "github.com/openshift/origin/pkg/build/apis/build/v1"
 	os_deploy_v1 "github.com/openshift/origin/pkg/deploy/apis/apps/v1"
 	image_v1 "github.com/openshift/origin/pkg/image/apis/image/v1"
 	os_route_v1 "github.com/openshift/origin/pkg/route/apis/route/v1"
@@ -90,6 +91,11 @@ func GetScheme() (*runtime.Scheme, error) {
 	// Adding the image scheme to support OpenShift ImageStreams
 	if err := image_v1.AddToScheme(scheme); err != nil {
 		return nil, errors.Wrap(err, "unable to add 'image' to scheme")
+	}
+
+	// Adding the build scheme to support OpenShift buildConfigs
+	if err := build_v1.AddToScheme(scheme); err != nil {
+		return nil, errors.Wrap(err, "unable to add 'build' to scheme")
 	}
 
 	return scheme, nil


### PR DESCRIPTION
This commit adds support for BuildConfigs to the Kedge spec. Now,
at the root level, BuildConfigs can be specified with the
"buildConfigs:" key, which takes in an array of BuildConfigSpec +
ObjectMeta definitions.

This commit also adds unit tests for this new behavior.