### PR TITLE
Add documentation regarding apply command / update current docs

### DIFF
--- a/docs/examples/build/README.md
+++ b/docs/examples/build/README.md
@@ -27,7 +27,7 @@ running build command.
 Deploy the kedge configs in `configs` directory:
 
 ```console
-$ kedge create -f configs/
+$ kedge apply -f configs/
 service "ticker" created
 deployment "ticker" created
 service "redis" created

--- a/docs/examples/includeResources/README.md
+++ b/docs/examples/includeResources/README.md
@@ -25,5 +25,5 @@ in which this config is specified.
 This does not change anything with respect to deploying applications.
 
 ```console
-$ kedge create -f app.yaml
+$ kedge apply -f app.yaml
 ```

--- a/docs/file-reference.md
+++ b/docs/file-reference.md
@@ -14,10 +14,10 @@ services:
     targetPort: 80
 ```
 
-> Now run the create command to deploy to Kubernetes
+> Now run the apply command to deploy to Kubernetes
 
 ```sh
-$ kedge create -f httpd.yaml
+$ kedge apply -f httpd.yaml
 deployment "httpd" created
 service "httpd" created
 ```

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -21,10 +21,10 @@ services:
     - 8080:80
 ```
 
-__2. Now run the create command to deploy to Kubernetes!__
+__2. Now run the apply command to deploy to Kubernetes!__
 
 ```sh
-$ kedge create -f httpd.yaml
+$ kedge apply -f httpd.yaml
 deployment "httpd" created
 service "httpd" created
 ```
@@ -33,7 +33,7 @@ __2.1. Alternatively, you can generate the raw Kubernetes artifact files and dep
 
 ```sh
 $ kedge generate -f httpd.yaml > output.yaml
-$ kubectl create -f output.yaml
+$ kubectl apply -f output.yaml
 ```
 
 __View the deployed service__

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -3,6 +3,16 @@
 * TOC
 {:toc}
 
+## Kedge Apply
+
+Deploy directly to Kubernetes, either updating or creating the artifacts if they don't exist.
+
+```sh
+$ kedge apply -f httpd.yaml
+deployment "httpd" created
+service "httpd" created
+```
+
 ## Kedge Create
 
 Deploy directly to Kubernetes without creating the artifacts. Internally, Kedge will generate the artifacts and then create it using the `kubectl` command.

--- a/examples/gitlab/README.md
+++ b/examples/gitlab/README.md
@@ -23,7 +23,7 @@ spec:
 
 ### Deploying on Kubernetes
 ```
-$ kedge create -f gitlab.yml -f redis.yml -f postgres.yml 
+$ kedge apply -f gitlab.yml -f redis.yml -f postgres.yml 
 persistentvolumeclaim "gitlab-data" created
 persistentvolumeclaim "gitlab-etc" created
 service "gitlab" created

--- a/examples/guestbook-demo/README.md
+++ b/examples/guestbook-demo/README.md
@@ -22,7 +22,7 @@ wget https://raw.githubusercontent.com/kedgeproject/kedge/master/examples/guestb
 2. Deploy using `kedge`
 
 ```sh
-$ kedge create -f backend.yaml -f frontend.yaml -f db.yaml
+$ kedge apply -f backend.yaml -f frontend.yaml -f db.yaml
 service "guestbook" created
 deployment "guestbook" created
 service "backend" created

--- a/examples/wordpress/README.md
+++ b/examples/wordpress/README.md
@@ -20,7 +20,7 @@ wget https://raw.githubusercontent.com/kedgeproject/kedge/master/examples/wordpr
 2. Deploy using `kedge`
 
 ```sh
-$ kedge create -f wordpress.yaml -f mariadb.yaml
+$ kedge apply -f wordpress.yaml -f mariadb.yaml
 persistentvolumeclaim "database" created
 service "database" created
 secret "database-root-password" created


### PR DESCRIPTION
Updates the current documentation we have to use the `kedge apply`
command rather than `kedge create`.

Mostly due to the fact that `kubectl apply` is more widely used than
`kubectl create`.

Closes https://github.com/kedgeproject/kedge/issues/479