### PR TITLE
Fixed kedge build error(archive/tar: write too long)

### DIFF
--- a/tests/cmd/cmd_test.go
+++ b/tests/cmd/cmd_test.go
@@ -15,6 +15,8 @@ import (
 var Fixtures = os.ExpandEnv("$GOPATH/src/github.com/kedgeproject/kedge/tests/cmd/fixtures/")
 var ProjectPath = "$GOPATH/src/github.com/kedgeproject/kedge/"
 var BinaryLocation = os.ExpandEnv(ProjectPath + "kedge")
+var imagename = "testrun"
+var context = "kedge-build/"
 
 func TestKedgeGenerate(t *testing.T) {
 	testCases := []struct {
@@ -94,4 +96,21 @@ func runCmd(t *testing.T, args []string) (string, error) {
 		return strings.TrimSpace(stdout.String()), err
 	}
 	return strings.TrimSpace(stdout.String()), nil
+}
+
+func Test_builderror(t *testing.T) {
+
+	cmdStr := fmt.Sprintf("%s build -i %s -c %s", BinaryLocation, imagename, context)
+	output, err := exec.Command("/bin/sh", "-c", cmdStr).Output()
+	if err != nil {
+		fmt.Println("Error executing command", err)
+	}
+	cmdStr = fmt.Sprintf("docker images | grep %s | awk '{print $1}'", imagename)
+	output, err = exec.Command("/bin/sh", "-c", cmdStr).Output()
+	if err != nil {
+		fmt.Println("Error executing command", err)
+	}
+	if strings.TrimSpace(string(output)) != imagename {
+		t.Errorf("Test Failed")
+	}
 }

--- a/tests/cmd/kedge-build/Dockerfile
+++ b/tests/cmd/kedge-build/Dockerfile
@@ -1,0 +1,2 @@
+FROM alpine
+CMD ping


### PR DESCRIPTION
Fixes #490

Current directory size:

```
$ du -sh
799M	.
```

Dockerfile:

```
$ cat Dockerfile
FROM centos:7
CMD ping
```

Upon running above Dockerfile, Now kedge can successfully built an image.

```
$ kedge build -i testrun
INFO[0000] Building image 'testrun' from directory 'kedge'
INFO[0010] Image 'testrun' from directory 'kedge' built successfully
```

(Problem resolved by adding check for file mode bits)