### PR TITLE
Make logo point to index

### DIFF
--- a/slate/source/layouts/layout.erb
+++ b/slate/source/layouts/layout.erb
@@ -52,7 +52,7 @@ under the License.
       </span>
     </a>
     <div class="toc-wrapper">
-      <%= image_tag "logo.png", class: 'logo' %>
+      <a href="/"><%= image_tag "logo.png", class: 'logo' %></a>
       <% if language_tabs.any? %>
         <div class="lang-selector">
           <% language_tabs.each do |lang| %>


### PR DESCRIPTION
Makes the slate file-reference page logo point to index when you click
on it (redirect back to http://kedgeproject.org)