### PR TITLE
Make small optimizations to the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,8 @@
 FROM golang:1.8
 
-WORKDIR /go/src/app
+WORKDIR /go/src/github.com/kedgeproject/kedge
 COPY . .
 
-RUN go-wrapper download
-RUN go-wrapper install
-RUN go get github.com/kubernetes/kubernetes/cmd/kubectl
+RUN go install
 
-ENTRYPOINT ["app"]
+ENTRYPOINT ["kedge"]


### PR DESCRIPTION
This commit makes some changes to the Dockerfile so we do not have
to pull kedge from GitHub all over again since we are copying the
local code to inside the image anyway.

This should be fine since we are building the image from the make
command, so it's safe to assume that the end user has cloned kedge
already and running then running the `make image` command.