### PR TITLE
Making size field optional in PVC

### DIFF
--- a/pkg/spec/types.go
+++ b/pkg/spec/types.go
@@ -35,6 +35,7 @@ type VolumeClaim struct {
 	// k8s: io.k8s.kubernetes.pkg.api.v1.PersistentVolumeClaimSpec
 	api_v1.PersistentVolumeClaimSpec `json:",inline"`
 	// Size of persistent volume
+	// +optional
 	Size string `json:"size"`
 	// k8s: io.k8s.kubernetes.pkg.apis.meta.v1.ObjectMeta
 	meta_v1.ObjectMeta `json:",inline"`


### PR DESCRIPTION
Added `//+optional` for `size` key in `VolumeClaim` defination.
This will make this field option in JSON schema.