### PR TITLE
Pass absolute path to JSON Schema docker command

### DIFF
--- a/scripts/update-json-schema.sh
+++ b/scripts/update-json-schema.sh
@@ -25,7 +25,7 @@ git clone "$GENERATOR_REPO" "$KEDGE_REPO_NAME"
 cd "$KEDGE_REPO_NAME"
 rm -rf "$OUTPUT_DIR"
 mkdir -p "$OUTPUT_DIR"
-docker run --rm -v "$OUTPUT_DIR":/data:Z "$KEDGE_JSON_SCHEMA_IMAGE"
+docker run --rm -v `pwd`/"$OUTPUT_DIR":/data:Z "$KEDGE_JSON_SCHEMA_IMAGE"
 
 # add relevant user information
 git config user.name "$GIT_USER"


### PR DESCRIPTION
To mount a host directory, we need to use absolute path to the
JSON Schema container image. Before this commit, the mounted path
was relative and was not producing the desired output. This commit
fixes that.