### PR TITLE
Added case for lowercase protocol

### DIFF
--- a/pkg/spec/resources.go
+++ b/pkg/spec/resources.go
@@ -669,9 +669,10 @@ func parsePortMapping(pm string) (*api_v1.ServicePort, error) {
 	// Case 3 - port/protocol
 	// Case 4 - port:targetPort/protocol
 	case 2:
-		switch api_v1.Protocol(protocolSplit[1]) {
+		protocolUpperCase := strings.ToUpper(protocolSplit[1])
+		switch api_v1.Protocol(protocolUpperCase) {
 		case api_v1.ProtocolTCP, api_v1.ProtocolUDP:
-			protocol = api_v1.Protocol(protocolSplit[1])
+			protocol = api_v1.Protocol(protocolUpperCase)
 		default:
 			return nil, fmt.Errorf("invalid protocol '%v' provided, the acceptable values are '%v' and '%v'", protocolSplit[1], api.ProtocolTCP, api.ProtocolUDP)
 		}

--- a/pkg/spec/resources_test.go
+++ b/pkg/spec/resources_test.go
@@ -1018,6 +1018,30 @@ func TestParsePortMapping(t *testing.T) {
 			success: true,
 		},
 		{
+			name:        "port/protocol(lowercase) is passed",
+			portMapping: "1337/udp",
+			servicePort: &api_v1.ServicePort{
+				Port: 1337,
+				TargetPort: intstr.IntOrString{
+					IntVal: 1337,
+				},
+				Protocol: api_v1.ProtocolUDP,
+			},
+			success: true,
+		},
+		{
+			name:        "port/protocol(tCp) is passed",
+			portMapping: "1337/tCp",
+			servicePort: &api_v1.ServicePort{
+				Port: 1337,
+				TargetPort: intstr.IntOrString{
+					IntVal: 1337,
+				},
+				Protocol: api_v1.ProtocolTCP,
+			},
+			success: true,
+		},
+		{
 			name:        "port:targetPort/protocol is passed",
 			portMapping: "1337:1338/UDP",
 			servicePort: &api_v1.ServicePort{


### PR DESCRIPTION
This will accept if someone specifies protocol as
tcp or Tcp or tCp. Likewise UDP also
Always return the protocol as Uppercase
Added test for two cases
#560 