### PR TITLE
Add capitalization to commands

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -28,7 +28,7 @@ import (
 // Represents the "apply" command
 var applyCmd = &cobra.Command{
 	Use:   "apply",
-	Short: "Apply a configuration to a resource on the Kubernetes cluster. This resource will be created if it doesn't exist yet.",
+	Short: "Apply (or create if it does not exist) a configuration to a resource on the Kubernetes cluster",
 	Run: func(cmd *cobra.Command, args []string) {
 		if err := ifFilesPassed(InputFiles); err != nil {
 			fmt.Println(err)

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -33,7 +33,7 @@ var PushImage, s2iBuild bool
 
 var buildCmd = &cobra.Command{
 	Use:   "build",
-	Short: "build application image",
+	Short: "Build application image",
 	Run: func(cmd *cobra.Command, args []string) {
 		if DockerImage == "" {
 			fmt.Println("Please specify the container image name using flag '--image' or '-i'")

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -41,7 +41,7 @@ var generateCmd = &cobra.Command{
 }
 
 func init() {
-	generateCmd.Flags().StringArrayVarP(&InputFiles, "files", "f", []string{}, "input files")
+	generateCmd.Flags().StringArrayVarP(&InputFiles, "files", "f", []string{}, "Input files")
 	generateCmd.MarkFlagRequired("files")
 	RootCmd.AddCommand(generateCmd)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -52,5 +52,5 @@ func Execute() {
 
 // Initialize all flags
 func init() {
-	RootCmd.PersistentFlags().BoolVarP(&GlobalVerbose, "verbose", "v", false, "verbose output")
+	RootCmd.PersistentFlags().BoolVarP(&GlobalVerbose, "verbose", "v", false, "Verbose output")
 }


### PR DESCRIPTION
The capitlization bothered me a tiny bit, so I created this PR. Also
reduces the "apply" short description to one section without a `.` in
order to similar with the other commands.