### PR TITLE
Improved help on error on kedge commands

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -17,7 +17,6 @@ limitations under the License.
 package cmd
 
 import (
-	"fmt"
 	"os"
 
 	pkgcmd "github.com/kedgeproject/kedge/pkg/cmd"
@@ -31,7 +30,7 @@ var applyCmd = &cobra.Command{
 	Short: "Apply (or create if it does not exist) a configuration to a resource on the Kubernetes cluster",
 	Run: func(cmd *cobra.Command, args []string) {
 		if err := ifFilesPassed(InputFiles); err != nil {
-			fmt.Println(err)
+			usageError(cmd.CommandPath(), err)
 			os.Exit(-1)
 		}
 
@@ -44,7 +43,6 @@ var applyCmd = &cobra.Command{
 		}
 
 		if err := pkgcmd.CreateArtifacts(InputFiles, false, SkipValidation, command...); err != nil {
-			fmt.Println(err)
 			os.Exit(-1)
 		}
 	},

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -36,7 +36,7 @@ var buildCmd = &cobra.Command{
 	Short: "Build application image",
 	Run: func(cmd *cobra.Command, args []string) {
 		if DockerImage == "" {
-			fmt.Println("Please specify the container image name using flag '--image' or '-i'")
+			usageError(cmd.CommandPath(), fmt.Errorf("Please specify the container image name using flag '--image' or '-i'"))
 			os.Exit(-1)
 		}
 
@@ -45,7 +45,7 @@ var buildCmd = &cobra.Command{
 				log.Warnf("Using source to image strategy for build, image will be by default pushed to internal container registry, so ignoring this flag")
 			}
 			if BuilderImage == "" {
-				fmt.Println("Please specify the builder image name using flag '--builder-image' or '-b'")
+				usageError(cmd.CommandPath(), fmt.Errorf("Please specify the builder image name using flag '--builder-image' or '-b'"))
 				os.Exit(-1)
 			}
 			if err := build.BuildS2I(DockerImage, DockerContext, BuilderImage, Namespace); err != nil {

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -30,7 +30,7 @@ var createCmd = &cobra.Command{
 	Short: "Create the resource on the Kubernetes cluster",
 	Run: func(cmd *cobra.Command, args []string) {
 		if err := ifFilesPassed(InputFiles); err != nil {
-			fmt.Println(err)
+			usageError(cmd.CommandPath(), err)
 			os.Exit(-1)
 		}
 

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -30,7 +30,7 @@ var deleteCmd = &cobra.Command{
 	Short: "Delete the resource from the Kubernetes cluster",
 	Run: func(cmd *cobra.Command, args []string) {
 		if err := ifFilesPassed(InputFiles); err != nil {
-			fmt.Println(err)
+			usageError(cmd.CommandPath(), err)
 			os.Exit(-1)
 		}
 

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -30,7 +30,7 @@ var generateCmd = &cobra.Command{
 	Short: "Generate Kubernetes resources from an app definition",
 	Run: func(cmd *cobra.Command, args []string) {
 		if err := ifFilesPassed(InputFiles); err != nil {
-			fmt.Println(err)
+			usageError(cmd.CommandPath(), err)
 			os.Exit(-1)
 		}
 		InputFiles = removeDuplicateFiles(InputFiles)

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -82,7 +82,7 @@ var initCmd = &cobra.Command{
 
 		// mandatory fields check
 		if name == "" || image == "" {
-			fmt.Println("--name and --image are mandatory flags, Please provide these flags")
+			usageError(cmd.CommandPath(), fmt.Errorf("--name and --image are mandatory flags, Please provide these flags"))
 			os.Exit(-1)
 		}
 		obj := App{}

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -19,6 +19,7 @@ package cmd
 import (
 	"path/filepath"
 
+	"fmt"
 	"log"
 
 	"github.com/pkg/errors"
@@ -58,4 +59,9 @@ func removeDuplicateFiles(inputFiles []string) []string {
 		}
 	}
 	return fileSet
+}
+
+// UsageError will show errors with suggestion to see help
+func usageError(cmdPath string, err error) {
+	fmt.Printf("%s\nSee '%s -h' for help and examples.\n", err, cmdPath)
 }


### PR DESCRIPTION
For example,
```
kedge apply
No files were passed. Please pass file(s) using '-f' or '--files'
See 'kedge apply -h' for help and examples.
```

Similar to `kubectl`